### PR TITLE
Fix v4 call (routes->tools) + shebang + migrate test fixtures

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * FlowMCP — MIT License
  *
@@ -9,7 +10,6 @@
  * For more information, see LICENSE.md and DISCLAIMER.md in the repo root.
  */
 
-#!/usr/bin/env node
 import { parseArgs } from 'node:util'
 
 import { FlowMcpCli } from './task/FlowMcpCli.mjs'

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -2721,7 +2721,7 @@ class FlowMcpCli {
         resolvedSchemas
             .forEach( ( { main } ) => {
                 const namespace = main[ 'namespace' ] || 'unknown'
-                const routes = main[ 'routes' ] || {}
+                const routes = main[ 'routes' ] || main[ 'tools' ] || {}
 
                 Object.keys( routes )
                     .forEach( ( routeName ) => {
@@ -2886,7 +2886,7 @@ class FlowMcpCli {
                 }
 
                 const namespace = main[ 'namespace' ] || 'unknown'
-                const routes = main[ 'routes' ] || {}
+                const routes = main[ 'routes' ] || main[ 'tools' ] || {}
 
                 Object.keys( routes )
                     .forEach( ( routeName ) => {
@@ -2925,7 +2925,7 @@ class FlowMcpCli {
             return { result }
         }
 
-        const matchedRouteConfig = matchedMain[ 'routes' ][ matchedRouteName ]
+        const matchedRouteConfig = ( matchedMain[ 'routes' ] || matchedMain[ 'tools' ] )[ matchedRouteName ]
         const matchedRouteParameters = matchedRouteConfig[ 'parameters' ] || []
         const matchedSchemaFilePath = matchedFile ? join( FlowMcpCli.#schemasDir(), matchedFile ) : null
         const { sharedLists: matchedSharedLists } = await FlowMcpCli.#resolveSharedListsForSchema( { 'main': matchedMain, 'filePath': matchedSchemaFilePath } )
@@ -6149,7 +6149,8 @@ class FlowMcpCli {
 
     static #filterMainRoutes( { main, routeNames } ) {
         const { namespace, name, description, version, docs, tags, root, requiredServerParams, headers, sharedLists, requiredLibraries } = main
-        const originalRoutes = main[ 'routes' ] || {}
+        const routesKey = main[ 'routes' ] ? 'routes' : ( main[ 'tools' ] ? 'tools' : 'routes' )
+        const originalRoutes = main[ routesKey ] || {}
         const filteredRoutes = {}
 
         routeNames
@@ -6169,7 +6170,7 @@ class FlowMcpCli {
             root,
             requiredServerParams,
             headers,
-            'routes': filteredRoutes
+            [ routesKey ]: filteredRoutes
         }
 
         if( sharedLists ) { filteredMain[ 'sharedLists' ] = sharedLists }

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -799,7 +799,8 @@ class FlowMcpCli {
 
                         if( routeName ) {
                             const { main } = await FlowMcpCli.#loadSchema( { filePath } )
-                            if( !main || !main[ 'routes' ] || !main[ 'routes' ][ routeName ] ) {
+                            const refRouteMap = main ? ( main[ 'routes' ] || main[ 'tools' ] ) : null
+                            if( !main || !refRouteMap || !refRouteMap[ routeName ] ) {
                                 invalidRefs.push( ref )
 
                                 return
@@ -3485,8 +3486,9 @@ class FlowMcpCli {
         const { main } = await FlowMcpCli.#loadSchema( { filePath: schemaFilePath, 'bustCache': force } )
 
         let extractedParameters = {}
-        if( main && main[ 'routes' ] && main[ 'routes' ][ routeName ] ) {
-            const routeConfig = main[ 'routes' ][ routeName ]
+        const extractRouteMap = main ? ( main[ 'routes' ] || main[ 'tools' ] ) : null
+        if( extractRouteMap && extractRouteMap[ routeName ] ) {
+            const routeConfig = extractRouteMap[ routeName ]
             const routeParameters = routeConfig[ 'parameters' ] || []
             const { sharedLists: resolvedLists } = await FlowMcpCli.#resolveSharedListsForSchema( { main, 'filePath': schemaFilePath } )
             const { parameters: transformed } = FlowMcpCli.#extractParameters( { routeParameters, 'sharedLists': resolvedLists } )
@@ -3738,12 +3740,12 @@ class FlowMcpCli {
 
         schemas
             .forEach( ( { main, file } ) => {
-                if( !main || !main[ 'routes' ] ) {
+                if( !main || !( main[ 'routes' ] || main[ 'tools' ] ) ) {
                     return
                 }
 
                 const namespace = main[ 'namespace' ] || 'unknown'
-                const routes = main[ 'routes' ]
+                const routes = main[ 'routes' ] || main[ 'tools' ]
                 const schemaTags = main[ 'tags' ] || []
                 const sharedLists = sharedListsMap[ file ] || {}
 

--- a/tests/helpers/mock-schema.mjs
+++ b/tests/helpers/mock-schema.mjs
@@ -10,7 +10,7 @@ const validSchema = {
     'headers': {
         'Accept': 'application/json'
     },
-    'routes': {
+    'tools': {
         'getData': {
             'method': 'GET',
             'description': 'Get test data',
@@ -48,7 +48,7 @@ const validSchemaWithServerParams = {
         'Authorization': 'Bearer {{API_KEY}}',
         'Content-Type': 'application/json'
     },
-    'routes': {
+    'tools': {
         'getUser': {
             'method': 'GET',
             'description': 'Get user data',

--- a/tests/integration/phase-1-friction.test.mjs
+++ b/tests/integration/phase-1-friction.test.mjs
@@ -16,13 +16,13 @@ function schemaFile( { namespace, requiredKeys = [], routeName = 'ping' } ) {
     namespace: '${namespace}',
     name: '${namespace} API',
     description: 'Test schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: ${JSON.stringify( requiredKeys )},
     headers: {},
-    routes: {
+    tools: {
         ${routeName}: { method: 'GET', description: 'Test', path: '/', parameters: [] }
     }
 }
@@ -51,7 +51,7 @@ describe( 'Phase 1 friction — empty env (Memo 032 PRD-12)', () => {
         const registry = {
             'name': SOURCE_NAME,
             'version': '1.0.0',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'testschema', 'file': 'testschema.mjs', 'name': 'testschema', 'requiredServerParams': [ 'TEST_KEY' ] }
             ]
@@ -61,7 +61,7 @@ describe( 'Phase 1 friction — empty env (Memo 032 PRD-12)', () => {
 
         const globalConfig = {
             'envPath': testHome.envPath(),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'builtin', 'schemaCount': 1 } }
         }

--- a/tests/integration/phase-2-3-friction.test.mjs
+++ b/tests/integration/phase-2-3-friction.test.mjs
@@ -16,13 +16,13 @@ function schemaFile( { namespace, requiredKeys = [], routeName = 'ping' } ) {
     namespace: '${namespace}',
     name: '${namespace} API',
     description: 'Test schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: ${JSON.stringify( requiredKeys )},
     headers: {},
-    routes: {
+    tools: {
         ${routeName}: { method: 'GET', description: 'Test', path: '/', parameters: [] }
     }
 }
@@ -51,7 +51,7 @@ describe( 'Phase 2/3 friction — full coverage (Memo 032 PRD-13)', () => {
         const registry = {
             'name': SOURCE_NAME,
             'version': '1.0.0',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'testschema', 'file': 'testschema.mjs', 'name': 'testschema', 'requiredServerParams': [ 'TEST_KEY' ] }
             ]
@@ -61,7 +61,7 @@ describe( 'Phase 2/3 friction — full coverage (Memo 032 PRD-13)', () => {
 
         const globalConfig = {
             'envPath': testHome.envPath(),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'builtin', 'schemaCount': 1 } }
         }

--- a/tests/unit/add-activation-guard.test.mjs
+++ b/tests/unit/add-activation-guard.test.mjs
@@ -16,13 +16,13 @@ function schemaFile( { namespace, requiredKeys = [], routeName = 'ping' } ) {
     namespace: '${namespace}',
     name: '${namespace} API',
     description: 'Test schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: ${JSON.stringify( requiredKeys )},
     headers: {},
-    routes: {
+    tools: {
         ${routeName}: { method: 'GET', description: 'Test', path: '/', parameters: [] }
     }
 }
@@ -57,7 +57,7 @@ describe( 'add — activation guard (Memo 032 PRD-10)', () => {
         const registry = {
             'name': SOURCE_NAME,
             'version': '1.0.0',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'guarded', 'file': 'guarded.mjs', 'name': 'guarded', 'requiredServerParams': [ 'GUARD_KEY' ] },
                 { 'namespace': 'free', 'file': 'free.mjs', 'name': 'free', 'requiredServerParams': [] }
@@ -68,7 +68,7 @@ describe( 'add — activation guard (Memo 032 PRD-10)', () => {
 
         const globalConfig = {
             'envPath': testHome.envPath(),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'builtin', 'schemaCount': 2 } }
         }

--- a/tests/unit/add-force-calltool-cache.test.mjs
+++ b/tests/unit/add-force-calltool-cache.test.mjs
@@ -25,13 +25,13 @@ beforeAll( async () => {
     namespace: 'forcesimple',
     name: 'Force Simple API',
     description: 'Simple schema for force add tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping endpoint',
@@ -46,13 +46,13 @@ beforeAll( async () => {
     namespace: 'forceparams',
     name: 'Force Params API',
     description: 'Schema with parameters for force tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getData: {
             method: 'GET',
             description: 'Get data with required param',
@@ -72,7 +72,7 @@ beforeAll( async () => {
         'name': 'forcesrc',
         'version': '1.0.0',
         'description': 'Test source for force tests',
-        'schemaSpec': '2.0.0',
+        'schemaSpec': '4.0.0',
         'schemas': [
             { 'namespace': 'forcesimple', 'file': 'simple.mjs', 'name': 'Force Simple API', 'requiredServerParams': [] },
             { 'namespace': 'forceparams', 'file': 'params.mjs', 'name': 'Force Params API', 'requiredServerParams': [] }
@@ -89,7 +89,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/auth-error-and-path-edge.test.mjs
+++ b/tests/unit/auth-error-and-path-edge.test.mjs
@@ -51,13 +51,13 @@ describe( 'FlowMcpCli.callTool — auth error without requiredServerParams (line
     namespace: 'autherrsrc',
     name: 'Auth Error API',
     description: 'Schema that triggers 401 without requiredServerParams',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         forbidden: {
             method: 'GET',
             description: 'Returns 401',
@@ -72,7 +72,7 @@ describe( 'FlowMcpCli.callTool — auth error without requiredServerParams (line
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Auth error test source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'autherrsrc', 'file': 'auth.mjs', 'name': 'Auth Error API', 'requiredServerParams': [] }
             ]
@@ -96,7 +96,7 @@ describe( 'FlowMcpCli.callTool — auth error without requiredServerParams (line
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }

--- a/tests/unit/call-list-tools.test.mjs
+++ b/tests/unit/call-list-tools.test.mjs
@@ -18,13 +18,13 @@ const CALL_SCHEMA_CONTENT = `export const main = {
     namespace: 'callapi',
     name: 'Call Test API',
     description: 'Schema for callListTools tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getStatus: {
             method: 'GET',
             description: 'Get status',
@@ -45,7 +45,7 @@ const TEST_REGISTRY = {
     'name': 'callsrc',
     'version': '1.0.0',
     'description': 'Test registry for call commands',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'baseDir': 'schemas/v2.0.0',
     'schemas': [
         {
@@ -62,7 +62,7 @@ const TEST_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123def',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {

--- a/tests/unit/call-tool-and-health.test.mjs
+++ b/tests/unit/call-tool-and-health.test.mjs
@@ -18,13 +18,13 @@ const HEALTH_SCHEMA_CONTENT = `export const main = {
     namespace: 'healthapi',
     name: 'Health Test API',
     description: 'Schema for callTool and health tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [ 'HEALTH_TEST_KEY' ],
     headers: {},
-    routes: {
+    tools: {
         getAnything: {
             method: 'GET',
             description: 'Get anything',
@@ -39,7 +39,7 @@ const HEALTH_REGISTRY = {
     'name': 'healthsrc',
     'version': '1.0.0',
     'description': 'Health test registry',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'healthapi',
@@ -54,13 +54,13 @@ const SIMPLE_SCHEMA_CONTENT = `export const main = {
     namespace: 'simpleapi',
     name: 'Simple Test API',
     description: 'Schema for callTool success test',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getData: {
             method: 'GET',
             description: 'Get data',
@@ -75,7 +75,7 @@ const SIMPLE_REGISTRY = {
     'name': 'callsrc2',
     'version': '1.0.0',
     'description': 'Simple test registry',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'simpleapi',
@@ -91,7 +91,7 @@ const TEST_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123def',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {
@@ -283,7 +283,7 @@ describe( 'FlowMcpCli.status deep health check', () => {
             'flowmcpCore': {
                 'version': '2.0.0',
                 'commit': 'abc123def',
-                'schemaSpec': '2.0.0'
+                'schemaSpec': '4.0.0'
             },
             'initialized': '2026-02-20T12:00:00.000Z',
             'sources': {
@@ -350,7 +350,7 @@ describe( 'FlowMcpCli.status deep health check', () => {
             'flowmcpCore': {
                 'version': '2.0.0',
                 'commit': 'abc123def',
-                'schemaSpec': '2.0.0'
+                'schemaSpec': '4.0.0'
             },
             'initialized': '2026-02-20T12:00:00.000Z',
             'sources': {

--- a/tests/unit/calltool-cache-flow.test.mjs
+++ b/tests/unit/calltool-cache-flow.test.mjs
@@ -24,13 +24,13 @@ const PRELOAD_SCHEMA = `export const main = {
     namespace: 'cachesrc',
     name: 'Cache Test API',
     description: 'Schema for cache tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         cachedPing: {
             method: 'GET',
             description: 'Cached ping',
@@ -52,13 +52,13 @@ const NOTESTS_SCHEMA = `export const main = {
     namespace: 'notestsrc',
     name: 'NoTest API',
     description: 'Schema without test definitions',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -73,13 +73,13 @@ const ENVREQ_SCHEMA = `export const main = {
     namespace: 'envreqsrc',
     name: 'EnvReq API',
     description: 'Schema requiring env',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [ 'MISSING_API_KEY' ],
     headers: {},
-    routes: {
+    tools: {
         check: {
             method: 'GET',
             description: 'Check',
@@ -95,7 +95,7 @@ const REGISTRY = {
     'name': 'cachesrc',
     'version': '1.0.0',
     'description': 'Cache test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         { 'namespace': 'cachesrc', 'file': 'cached.mjs', 'name': 'Cache Test API', 'requiredServerParams': [] },
         { 'namespace': 'notestsrc', 'file': 'notest.mjs', 'name': 'NoTest API', 'requiredServerParams': [] },
@@ -139,7 +139,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/calltool-edge-paths.test.mjs
+++ b/tests/unit/calltool-edge-paths.test.mjs
@@ -20,13 +20,13 @@ const SCHEMA_CONTENT = `export const main = {
     namespace: 'calledgesrc',
     name: 'CallEdge API',
     description: 'Schema for callTool edge case tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Simple ping',
@@ -52,7 +52,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'CallEdge test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'calledgesrc',
@@ -82,7 +82,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/calltool-fetch-failure.test.mjs
+++ b/tests/unit/calltool-fetch-failure.test.mjs
@@ -22,13 +22,13 @@ const AUTH_FAIL_SCHEMA = `export const main = {
     namespace: 'fetchfail',
     name: 'Fetch Fail API',
     description: 'Schema for fetch failure tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [ 'FAKE_API_KEY' ],
     headers: {},
-    routes: {
+    tools: {
         authFail: {
             method: 'GET',
             description: 'Returns 401',
@@ -74,7 +74,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Fetch failure test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'fetchfail',
@@ -116,7 +116,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/calltool-v4-tools.test.mjs
+++ b/tests/unit/calltool-v4-tools.test.mjs
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { writeFile, mkdir, rm, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir, homedir } from 'node:os'
+
+import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
+
+
+// Regression test for the v4 `call` blocker (Memo 062):
+// callTool / callListTools / #filterMainRoutes previously only read main['routes']
+// (v2 spec). v4 schemas use main['tools'] and were therefore not callable.
+// All existing call tests use `routes:` fixtures, so the v4 path was never exercised.
+
+const GLOBAL_CONFIG_DIR = join( homedir(), '.flowmcp' )
+const GLOBAL_CONFIG_PATH = join( GLOBAL_CONFIG_DIR, 'config.json' )
+const SCHEMAS_DIR = join( GLOBAL_CONFIG_DIR, 'schemas' )
+const SOURCE_NAME = 'v4toolssrc'
+const SOURCE_DIR = join( SCHEMAS_DIR, SOURCE_NAME )
+const ENV_PATH = join( GLOBAL_CONFIG_DIR, '.env.v4toolstest' )
+const TEST_CWD = join( tmpdir(), 'flowmcp-cli-v4-tools' )
+const LOCAL_CONFIG_DIR = join( TEST_CWD, '.flowmcp' )
+const LOCAL_CONFIG_PATH = join( LOCAL_CONFIG_DIR, 'config.json' )
+const CACHE_DIR = join( GLOBAL_CONFIG_DIR, 'cache' )
+
+let originalGlobalConfig = null
+let globalConfigExisted = false
+
+const V4_SCHEMA = `export const main = {
+    namespace: 'v4toolssrc',
+    name: 'V4 Tools API',
+    description: 'v4 schema that uses the tools key instead of routes',
+    version: '4.0.0',
+    docs: [],
+    tags: [ 'test' ],
+    root: 'https://httpbin.org',
+    requiredServerParams: [],
+    headers: {},
+    tools: {
+        getPing: {
+            method: 'GET',
+            description: 'Ping via the v4 tools key',
+            path: '/get',
+            parameters: []
+        }
+    }
+}
+`
+
+const REGISTRY = {
+    'name': 'v4toolssrc',
+    'version': '1.0.0',
+    'description': 'v4 tools test source',
+    'schemaSpec': '4.0.0',
+    'schemas': [
+        { 'namespace': 'v4toolssrc', 'file': 'v4tools.mjs', 'name': 'V4 Tools API', 'requiredServerParams': [] }
+    ]
+}
+
+const LOCAL_CONFIG = {
+    'root': '~/.flowmcp',
+    'defaultGroup': 'v4-test',
+    'groups': {
+        'v4-test': {
+            'description': 'v4 tools test group',
+            'tools': [
+                'v4toolssrc/v4tools.mjs::getPing'
+            ]
+        }
+    }
+}
+
+
+beforeAll( async () => {
+    try {
+        originalGlobalConfig = await readFile( GLOBAL_CONFIG_PATH, 'utf-8' )
+        globalConfigExisted = true
+    } catch {
+        globalConfigExisted = false
+    }
+
+    await mkdir( SOURCE_DIR, { recursive: true } )
+    await writeFile( join( SOURCE_DIR, 'v4tools.mjs' ), V4_SCHEMA, 'utf-8' )
+    await writeFile( join( SOURCE_DIR, '_registry.json' ), JSON.stringify( REGISTRY, null, 4 ), 'utf-8' )
+
+    await writeFile( ENV_PATH, 'TEST_KEY=abc\n', 'utf-8' )
+
+    const globalConfig = {
+        'envPath': ENV_PATH,
+        'flowmcpCore': { 'version': '4.0.0', 'commit': 'test', 'schemaSpec': '4.0.0' },
+        'initialized': new Date().toISOString(),
+        'sources': { 'v4toolssrc': { 'type': 'builtin', 'schemaCount': 1 } }
+    }
+
+    if( globalConfigExisted && originalGlobalConfig ) {
+        const parsed = JSON.parse( originalGlobalConfig )
+        parsed[ 'sources' ] = parsed[ 'sources' ] || {}
+        parsed[ 'sources' ][ 'v4toolssrc' ] = globalConfig[ 'sources' ][ 'v4toolssrc' ]
+        parsed[ 'envPath' ] = ENV_PATH
+        await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( parsed, null, 4 ), 'utf-8' )
+    } else {
+        await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( globalConfig, null, 4 ), 'utf-8' )
+    }
+
+    await mkdir( LOCAL_CONFIG_DIR, { recursive: true } )
+    await writeFile( LOCAL_CONFIG_PATH, JSON.stringify( LOCAL_CONFIG, null, 4 ), 'utf-8' )
+} )
+
+
+afterAll( async () => {
+    if( globalConfigExisted && originalGlobalConfig ) {
+        await writeFile( GLOBAL_CONFIG_PATH, originalGlobalConfig, 'utf-8' )
+    }
+
+    await rm( SOURCE_DIR, { recursive: true, force: true } ).catch( () => {} )
+    await rm( TEST_CWD, { recursive: true, force: true } ).catch( () => {} )
+    await rm( ENV_PATH, { force: true } ).catch( () => {} )
+    await rm( CACHE_DIR, { recursive: true, force: true } ).catch( () => {} )
+} )
+
+
+describe( 'FlowMcpCli v4 schema (tools key) is callable', () => {
+    it( 'callListTools lists the v4 tool', async () => {
+        const { result } = await FlowMcpCli.callListTools( { 'cwd': TEST_CWD } )
+
+        expect( result[ 'status' ] ).toBe( true )
+
+        const v4Tool = result[ 'tools' ]
+            .find( ( tool ) => {
+                const isMatch = tool[ 'namespace' ] === 'v4toolssrc'
+
+                return isMatch
+            } )
+
+        expect( v4Tool ).toBeDefined()
+        expect( v4Tool[ 'routeName' ] ).toBe( 'getPing' )
+    }, 15000 )
+
+
+    it( 'callTool resolves and executes the v4 tool', async () => {
+        const { result: listResult } = await FlowMcpCli.callListTools( { 'cwd': TEST_CWD } )
+        const v4Tool = listResult[ 'tools' ]
+            .find( ( tool ) => {
+                const isMatch = tool[ 'namespace' ] === 'v4toolssrc'
+
+                return isMatch
+            } )
+
+        const { result } = await FlowMcpCli.callTool( {
+            'toolName': v4Tool[ 'toolName' ],
+            'cwd': TEST_CWD
+        } )
+
+        // Must NOT be "tool not found" — that was the v4 blocker symptom.
+        const notFound = result[ 'error' ] && result[ 'error' ].includes( 'not found in active tools' )
+        expect( notFound ).toBeFalsy()
+        expect( result[ 'status' ] ).toBe( true )
+    }, 20000 )
+} )

--- a/tests/unit/dev-env-acquire.test.mjs
+++ b/tests/unit/dev-env-acquire.test.mjs
@@ -16,13 +16,13 @@ function schemaFile( { namespace, requiredKeys } ) {
     namespace: '${namespace}',
     name: '${namespace} API',
     description: 'Test schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: ${JSON.stringify( requiredKeys )},
     headers: {},
-    routes: {
+    tools: {
         ping: { method: 'GET', description: 'Ping', path: '/ping', parameters: [] }
     }
 }
@@ -55,7 +55,7 @@ describe( 'FlowMcpCli.devEnvAcquire (Memo 032 PRD-08)', () => {
         const registry = {
             'name': SOURCE_NAME,
             'version': '1.0.0',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'gov', 'file': 'gov.mjs', 'name': 'gov', 'requiredServerParams': [ 'NASA_API_KEY', 'CONGRESS_API_KEY' ] },
                 { 'namespace': 'sci', 'file': 'sci.mjs', 'name': 'sci', 'requiredServerParams': [ 'EBIRD_API_KEY' ] }
@@ -66,7 +66,7 @@ describe( 'FlowMcpCli.devEnvAcquire (Memo 032 PRD-08)', () => {
 
         const globalConfig = {
             'envPath': testHome.envPath(),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'builtin', 'schemaCount': 2 } }
         }

--- a/tests/unit/dev-env-doctor.test.mjs
+++ b/tests/unit/dev-env-doctor.test.mjs
@@ -16,7 +16,7 @@ function makeRegistry( { schemas } ) {
         'name': SOURCE_NAME,
         'version': '1.0.0',
         'description': 'Doctor test source',
-        'schemaSpec': '2.0.0',
+        'schemaSpec': '4.0.0',
         schemas
     }
 }
@@ -27,13 +27,13 @@ function schemaFile( { namespace, requiredKeys = [] } ) {
     namespace: '${namespace}',
     name: '${namespace} API',
     description: 'Test schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: ${JSON.stringify( requiredKeys )},
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -91,7 +91,7 @@ describe( 'FlowMcpCli.devEnvDoctor (Memo 032 PRD-09)', () => {
 
         const globalConfig = {
             'envPath': testHome.envPath(),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'builtin', 'schemaCount': 2 } }
         }

--- a/tests/unit/dev-lists.test.mjs
+++ b/tests/unit/dev-lists.test.mjs
@@ -47,13 +47,13 @@ const SCHEMA_REFERENCING_ALIAS = `export const main = {
     namespace: 'devlistsrc',
     name: 'DevLists API',
     description: 'Test schema referencing alias in enum',
-    version: '3.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getChainData: {
             method: 'GET',
             description: 'Get chain data',
@@ -73,13 +73,13 @@ const SCHEMA_NO_ALIAS = `export const main = {
     namespace: 'devlistsrc',
     name: 'Plain API',
     description: 'Test schema without alias reference',
-    version: '3.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://example.com',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -94,7 +94,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'DevLists test source',
-    'schemaSpec': '3.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'devlistsrc',
@@ -129,7 +129,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '4.0.0',
             'commit': 'abc123',
-            'schemaSpec': '3.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/findlistsdir-and-calltool-deep.test.mjs
+++ b/tests/unit/findlistsdir-and-calltool-deep.test.mjs
@@ -56,14 +56,14 @@ describe( 'FlowMcpCli.list — shared lists in parent dir exercises #findListsDi
     namespace: 'parentlistsrc',
     name: 'Parent List API',
     description: 'Schema in subdir with shared lists in parent',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     sharedLists: [ 'items' ],
-    routes: {
+    tools: {
         selectItem: {
             method: 'GET',
             description: 'Select item',
@@ -83,7 +83,7 @@ describe( 'FlowMcpCli.list — shared lists in parent dir exercises #findListsDi
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Parent list test',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 {
                     'namespace': 'parentlistsrc',
@@ -117,7 +117,7 @@ describe( 'FlowMcpCli.list — shared lists in parent dir exercises #findListsDi
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }
@@ -191,7 +191,7 @@ describe( 'FlowMcpCli.callTool — with group and nonexistent group schema', () 
         if( !globalConfigExisted ) {
             const globalConfig = {
                 'envPath': ENV_PATH,
-                'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+                'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
                 'initialized': new Date().toISOString(),
                 'sources': {}
             }
@@ -233,13 +233,13 @@ describe( 'FlowMcpCli.list — with schemasDir in local config exercises line 47
     namespace: 'schemadirtest',
     name: 'SchemasDir API',
     description: 'Test schemasDir config',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -254,7 +254,7 @@ describe( 'FlowMcpCli.list — with schemasDir in local config exercises line 47
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'SchemasDir test',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'schemadirtest', 'file': 'sdtest.mjs', 'name': 'SchemasDir API', 'requiredServerParams': [] }
             ]
@@ -279,7 +279,7 @@ describe( 'FlowMcpCli.list — with schemasDir in local config exercises line 47
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }
@@ -329,13 +329,13 @@ describe( 'FlowMcpCli.add — with force flag exercises bustCache', () => {
     namespace: 'forcesrc',
     name: 'Force API',
     description: 'Force test',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -350,7 +350,7 @@ describe( 'FlowMcpCli.add — with force flag exercises bustCache', () => {
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Force test source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'forcesrc', 'file': 'force.mjs', 'name': 'Force API', 'requiredServerParams': [] }
             ]
@@ -361,7 +361,7 @@ describe( 'FlowMcpCli.add — with force flag exercises bustCache', () => {
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }

--- a/tests/unit/group-append.test.mjs
+++ b/tests/unit/group-append.test.mjs
@@ -17,13 +17,13 @@ const DEMO_SCHEMA = `export const main = {
     namespace: 'appendtest',
     name: 'Append Test API',
     description: 'Schema for group append tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         routeA: {
             method: 'GET',
             description: 'Route A',
@@ -45,7 +45,7 @@ const TEST_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {

--- a/tests/unit/handlers-and-test-deep.test.mjs
+++ b/tests/unit/handlers-and-test-deep.test.mjs
@@ -50,13 +50,13 @@ describe( 'FlowMcpCli.callTool with schema that exports handlers — exercises #
     namespace: 'handlersrc',
     name: 'Handler API',
     description: 'Schema with handlers function',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping with handler',
@@ -79,7 +79,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Handler test source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'handlersrc', 'file': 'with-handler.mjs', 'name': 'Handler API', 'requiredServerParams': [] }
             ]
@@ -103,7 +103,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }
@@ -164,13 +164,13 @@ describe( 'FlowMcpCli.callTool with schema that exports broken handlers — exer
     namespace: 'brokenhandler',
     name: 'Broken Handler API',
     description: 'Schema with broken handlers',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -189,7 +189,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Broken handler test',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'brokenhandler', 'file': 'broken.mjs', 'name': 'Broken Handler API', 'requiredServerParams': [] }
             ]
@@ -213,7 +213,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }
@@ -264,13 +264,13 @@ describe( 'FlowMcpCli.test with schemaPath — exercises getAllTests and schemaP
     namespace: 'testpathsrc',
     name: 'Test Path API',
     description: 'Schema with tests for schemaPath test flow',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping route with test',
@@ -288,7 +288,7 @@ describe( 'FlowMcpCli.test with schemaPath — exercises getAllTests and schemaP
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'Test path source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'testpathsrc', 'file': 'testable.mjs', 'name': 'Test Path API', 'requiredServerParams': [] }
             ]
@@ -299,7 +299,7 @@ describe( 'FlowMcpCli.test with schemaPath — exercises getAllTests and schemaP
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }
@@ -407,13 +407,13 @@ describe( 'FlowMcpCli.test with schema that has no tests array', () => {
     namespace: 'notests',
     name: 'No Tests API',
     description: 'Schema without tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -428,7 +428,7 @@ describe( 'FlowMcpCli.test with schema that has no tests array', () => {
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'No tests source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'notests', 'file': 'notests.mjs', 'name': 'No Tests API', 'requiredServerParams': [] }
             ]
@@ -455,7 +455,7 @@ describe( 'FlowMcpCli.test with schema that has no tests array', () => {
 
         const globalConfig = {
             'envPath': ENV_PATH,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
         }

--- a/tests/unit/handlers-with-sharedlists.test.mjs
+++ b/tests/unit/handlers-with-sharedlists.test.mjs
@@ -31,14 +31,14 @@ beforeAll( async () => {
     namespace: 'hslsrc',
     name: 'HSL API',
     description: 'Schema with handlers and shared lists',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     sharedLists: [ 'colors' ],
-    routes: {
+    tools: {
         pickColor: {
             method: 'GET',
             description: 'Pick a color',
@@ -68,7 +68,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
         'name': SOURCE_NAME,
         'version': '1.0.0',
         'description': 'HSL test source',
-        'schemaSpec': '2.0.0',
+        'schemaSpec': '4.0.0',
         'schemas': [
             { 'namespace': 'hslsrc', 'file': 'hsl.mjs', 'name': 'HSL API', 'requiredServerParams': [] }
         ]
@@ -79,7 +79,7 @@ export const handlers = ( { sharedLists, libraries } ) => {
 
     const globalConfig = {
         'envPath': ENV_PATH,
-        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
         'initialized': new Date().toISOString(),
         'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
     }

--- a/tests/unit/help-and-edge-cases.test.mjs
+++ b/tests/unit/help-and-edge-cases.test.mjs
@@ -31,13 +31,13 @@ beforeAll( async () => {
     namespace: 'helpsrc',
     name: 'Help Test API',
     description: 'Schema for help tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -52,7 +52,7 @@ beforeAll( async () => {
         'name': SOURCE_NAME,
         'version': '1.0.0',
         'description': 'Help test source',
-        'schemaSpec': '2.0.0',
+        'schemaSpec': '4.0.0',
         'schemas': [
             {
                 'namespace': 'helpsrc',
@@ -72,7 +72,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/internal-helpers-coverage.test.mjs
+++ b/tests/unit/internal-helpers-coverage.test.mjs
@@ -50,13 +50,13 @@ describe( 'FlowMcpCli.schemas with source without registry — exercises listSch
     namespace: 'noregistry',
     name: 'No Registry API',
     description: 'Schema without registry',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -76,7 +76,7 @@ describe( 'FlowMcpCli.schemas with source without registry — exercises listSch
             'flowmcpCore': {
                 'version': '2.0.0',
                 'commit': 'abc123',
-                'schemaSpec': '2.0.0'
+                'schemaSpec': '4.0.0'
             },
             'initialized': new Date().toISOString(),
             'sources': {
@@ -210,13 +210,13 @@ describe( 'FlowMcpCli.list with toolRef without route — exercises parseToolRef
     namespace: 'toolrefsrc',
     name: 'ToolRef API',
     description: 'Schema for toolRef tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         routeA: {
             method: 'GET',
             description: 'Route A',
@@ -237,7 +237,7 @@ describe( 'FlowMcpCli.list with toolRef without route — exercises parseToolRef
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'ToolRef test source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 {
                     'namespace': 'toolrefsrc',
@@ -274,7 +274,7 @@ describe( 'FlowMcpCli.list with toolRef without route — exercises parseToolRef
             'flowmcpCore': {
                 'version': '2.0.0',
                 'commit': 'abc123',
-                'schemaSpec': '2.0.0'
+                'schemaSpec': '4.0.0'
             },
             'initialized': new Date().toISOString(),
             'sources': {

--- a/tests/unit/namespace-index.test.mjs
+++ b/tests/unit/namespace-index.test.mjs
@@ -8,18 +8,18 @@ import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
-function makeSchema( { namespace, routes = {}, resources = {}, prompts = {}, skills = [] } ) {
+function makeSchema( { namespace, tools = {}, resources = {}, prompts = {}, skills = [] } ) {
     return {
         namespace,
         name: `${namespace} API`,
         description: 'Test schema',
-        version: '2.0.0',
+        version: '4.0.0',
         docs: [],
         tags: [ 'test' ],
         root: 'https://example.com',
         requiredServerParams: [],
         headers: {},
-        routes,
+        tools,
         resources,
         prompts,
         skills
@@ -27,9 +27,9 @@ function makeSchema( { namespace, routes = {}, resources = {}, prompts = {}, ski
 }
 
 
-function schemaEntry( { namespace, file, source = 'testsrc', routes = {}, resources = {}, prompts = {}, skills = [] } ) {
+function schemaEntry( { namespace, file, source = 'testsrc', tools = {}, resources = {}, prompts = {}, skills = [] } ) {
     return {
-        'main': makeSchema( { namespace, routes, resources, prompts, skills } ),
+        'main': makeSchema( { namespace, tools, resources, prompts, skills } ),
         file,
         source
     }
@@ -61,7 +61,7 @@ describe( 'parseSpecId logic — verified via index key structure', () => {
             schemaEntry( {
                 'namespace': 'moralis',
                 'file': 'nftApi.mjs',
-                'routes': { 'getBlock': {} }
+                'tools': { 'getBlock': {} }
             } )
         ]
 
@@ -123,12 +123,12 @@ describe( 'Collision detection', () => {
             schemaEntry( {
                 'namespace': 'moralis',
                 'file': 'schemaA.mjs',
-                'routes': { 'getBlock': {} }
+                'tools': { 'getBlock': {} }
             } ),
             schemaEntry( {
                 'namespace': 'moralis',
                 'file': 'schemaB.mjs',
-                'routes': { 'getBlock': {} }
+                'tools': { 'getBlock': {} }
             } )
         ]
 
@@ -142,9 +142,9 @@ describe( 'Collision detection', () => {
 
     it( 'three schemas with same namespace+tool merge into one collision entry', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'foo', 'file': 'a.mjs', 'routes': { 'ping': {} } } ),
-            schemaEntry( { 'namespace': 'foo', 'file': 'b.mjs', 'routes': { 'ping': {} } } ),
-            schemaEntry( { 'namespace': 'foo', 'file': 'c.mjs', 'routes': { 'ping': {} } } )
+            schemaEntry( { 'namespace': 'foo', 'file': 'a.mjs', 'tools': { 'ping': {} } } ),
+            schemaEntry( { 'namespace': 'foo', 'file': 'b.mjs', 'tools': { 'ping': {} } } ),
+            schemaEntry( { 'namespace': 'foo', 'file': 'c.mjs', 'tools': { 'ping': {} } } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -161,8 +161,8 @@ describe( 'Collision detection', () => {
 
     it( 'no collision when different namespaces use same route name', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'ns1', 'file': 'a.mjs', 'routes': { 'getData': {} } } ),
-            schemaEntry( { 'namespace': 'ns2', 'file': 'b.mjs', 'routes': { 'getData': {} } } )
+            schemaEntry( { 'namespace': 'ns1', 'file': 'a.mjs', 'tools': { 'getData': {} } } ),
+            schemaEntry( { 'namespace': 'ns2', 'file': 'b.mjs', 'tools': { 'getData': {} } } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -179,8 +179,8 @@ describe( 'Collision detection', () => {
 describe( 'Multi-part container grouping', () => {
     it( 'nftApi-part1.mjs and nftApi-part2.mjs group under moralis/nftApi', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part1.mjs', 'routes': { 'getNft': {} } } ),
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part2.mjs', 'routes': { 'getNftMetadata': {} } } )
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part1.mjs', 'tools': { 'getNft': {} } } ),
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part2.mjs', 'tools': { 'getNftMetadata': {} } } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -193,7 +193,7 @@ describe( 'Multi-part container grouping', () => {
 
     it( 'single-part walletApi.mjs becomes containers["moralis/walletApi"] with one file', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'moralis', 'file': 'walletApi.mjs', 'routes': { 'getWallet': {} } } )
+            schemaEntry( { 'namespace': 'moralis', 'file': 'walletApi.mjs', 'tools': { 'getWallet': {} } } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -204,9 +204,9 @@ describe( 'Multi-part container grouping', () => {
 
     it( 'three parts collapse to one container key', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part1.mjs', 'routes': {} } ),
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part2.mjs', 'routes': {} } ),
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part3.mjs', 'routes': {} } )
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part1.mjs', 'tools': {} } ),
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part2.mjs', 'tools': {} } ),
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi-part3.mjs', 'tools': {} } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -225,7 +225,7 @@ describe( 'Schema skipping — missing namespace', () => {
                 'main': {
                     'name': 'No NS',
                     'description': 'Missing namespace',
-                    'routes': { 'ping': {} }
+                    'tools': { 'ping': {} }
                 },
                 'file': 'no-ns.mjs',
                 'source': 'test'
@@ -247,7 +247,7 @@ describe( 'Schema skipping — missing namespace', () => {
 describe( 'Index metadata', () => {
     it( 'index contains builtAt ISO string and schemaCount', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'ns', 'file': 'api.mjs', 'routes': { 'get': {} } } )
+            schemaEntry( { 'namespace': 'ns', 'file': 'api.mjs', 'tools': { 'get': {} } } )
         ]
 
         const { index } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -275,7 +275,7 @@ describe( 'Cache write and read roundtrip', () => {
 
     it( 'written index can be read back with identical content', async () => {
         const schemas = [
-            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi.mjs', 'routes': { 'getNft': {} } } )
+            schemaEntry( { 'namespace': 'moralis', 'file': 'nftApi.mjs', 'tools': { 'getNft': {} } } )
         ]
 
         const { index: originalIndex } = await FlowMcpCli.__testOnly_buildIndex( { schemas } )
@@ -364,7 +364,7 @@ describe( 'parseSpecId — invalid inputs produce no index entry', () => {
             {
                 'main': {
                     'namespace': 'alias',
-                    'routes': { 'doThing': {} }
+                    'tools': { 'doThing': {} }
                 },
                 'file': 'alias.mjs',
                 'source': 'test'

--- a/tests/unit/output-format-filter.test.mjs
+++ b/tests/unit/output-format-filter.test.mjs
@@ -86,7 +86,7 @@ describe( 'PRD-006: #computeDeclared', () => {
 
     it( 'accepts legacy "routes" key for tools', () => {
         const { declared } = FlowMcpCli._testHook_computeDeclared( {
-            'main': { 'routes': {} }
+            'main': { 'tools': {} }
         } )
 
         expect( declared[ 'tool' ] ).toBe( true )

--- a/tests/unit/remove-and-misc-paths.test.mjs
+++ b/tests/unit/remove-and-misc-paths.test.mjs
@@ -21,13 +21,13 @@ const SIMPLE_SCHEMA = `export const main = {
     namespace: 'deepremove',
     name: 'DeepRemove Simple API',
     description: 'Simple schema for remove and misc path tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Simple ping endpoint',
@@ -42,13 +42,13 @@ const PARAMS_SCHEMA = `export const main = {
     namespace: 'deepremoveparams',
     name: 'DeepRemove Params API',
     description: 'Schema with various parameter types for extraction tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         noZParam: {
             method: 'GET',
             description: 'Route with parameter that has no z field',
@@ -100,13 +100,13 @@ const CACHED_SCHEMA = `export const main = {
     namespace: 'deepremovecached',
     name: 'DeepRemove Cached API',
     description: 'Schema with preload route and params for cache key test',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         cachedSearch: {
             method: 'GET',
             description: 'Cached search with user param',
@@ -127,7 +127,7 @@ const REGISTRY = {
     'name': 'deepremove',
     'version': '1.0.0',
     'description': 'Registry for remove and misc path tests',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'deepremove',
@@ -176,7 +176,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123deepremove',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/required-libraries-and-debug.test.mjs
+++ b/tests/unit/required-libraries-and-debug.test.mjs
@@ -24,14 +24,14 @@ const REQLIBS_SCHEMA = `export const main = {
     namespace: 'reqlibs',
     name: 'Required Libs API',
     description: 'Schema with required libraries',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     requiredLibraries: [ 'zod' ],
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping with lib',
@@ -56,7 +56,7 @@ const REQLIBS_REGISTRY = {
     'name': REQLIBS_SOURCE_NAME,
     'version': '1.0.0',
     'description': 'RequiredLibraries test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'reqlibs',
@@ -71,14 +71,14 @@ const DEBUG_SCHEMA = `export const main = {
     namespace: 'debugsrc',
     name: 'Debug API',
     description: 'Schema for debug test',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     requiredLibraries: [ 'nonexistent-module-xyz-flowmcp-test' ],
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -103,7 +103,7 @@ const DEBUG_REGISTRY = {
     'name': DEBUG_SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Debug test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'debugsrc',
@@ -135,7 +135,7 @@ beforeAll( async () => {
 
     const globalConfig = {
         'envPath': ENV_PATH,
-        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
         'initialized': new Date().toISOString(),
         'sources': {
             [REQLIBS_SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 },

--- a/tests/unit/search-add-remove-list.test.mjs
+++ b/tests/unit/search-add-remove-list.test.mjs
@@ -18,13 +18,13 @@ const DEMO_SCHEMA_CONTENT = `export const main = {
     namespace: 'testdemo',
     name: 'Test Demo API',
     description: 'Simple demo schema for CLI testing',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [ 'https://example.com/docs' ],
     tags: [ 'demo', 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: { 'Accept': 'application/json' },
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Simple ping endpoint for testing',
@@ -52,13 +52,13 @@ const SECOND_SCHEMA_CONTENT = `export const main = {
     namespace: 'cryptotest',
     name: 'Crypto Test API',
     description: 'Crypto price data for testing',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'crypto', 'price' ],
     root: 'https://api.example.com',
     requiredServerParams: [ 'CRYPTO_KEY' ],
     headers: { 'Authorization': 'Bearer {{CRYPTO_KEY}}' },
-    routes: {
+    tools: {
         getPrice: {
             method: 'GET',
             description: 'Get token price by symbol',
@@ -79,7 +79,7 @@ const TEST_REGISTRY = {
     'name': 'test-source',
     'version': '1.0.0',
     'description': 'Test registry',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'baseDir': 'schemas/v2.0.0',
     'schemas': [
         {
@@ -102,7 +102,7 @@ const TEST_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {

--- a/tests/unit/shared-lists-and-misc.test.mjs
+++ b/tests/unit/shared-lists-and-misc.test.mjs
@@ -22,14 +22,14 @@ const SCHEMA_WITH_SHARED_LISTS = `export const main = {
     namespace: 'slsrc',
     name: 'SharedList API',
     description: 'Schema with shared lists for coverage tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     sharedLists: [ 'items' ],
-    routes: {
+    tools: {
         selectItem: {
             method: 'GET',
             description: 'Select item from shared list',
@@ -55,13 +55,13 @@ const SCHEMA_SIMPLE = `export const main = {
     namespace: 'slsimple',
     name: 'SL Simple API',
     description: 'Simple schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -76,7 +76,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'SharedList test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'slsrc',
@@ -109,7 +109,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/shared-lists-null-and-edge.test.mjs
+++ b/tests/unit/shared-lists-null-and-edge.test.mjs
@@ -27,14 +27,14 @@ const SCHEMA_NO_LISTS = `export const main = {
     namespace: 'nolistssrc',
     name: 'No Lists API',
     description: 'Schema with sharedLists but no _lists dir',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     sharedLists: [ 'nonexistent' ],
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -60,14 +60,14 @@ const SCHEMA_BROKEN_LISTS = `export const main = {
     namespace: 'brokenlistsrc',
     name: 'Broken Lists API',
     description: 'Schema referencing a broken shared list file',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
     sharedLists: [ 'broken' ],
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -91,7 +91,7 @@ const NOLISTS_REGISTRY = {
     'name': NOLISTS_SOURCE,
     'version': '1.0.0',
     'description': 'No lists test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'nolistssrc',
@@ -107,7 +107,7 @@ const BROKENLISTS_REGISTRY = {
     'name': BROKENLISTS_SOURCE,
     'version': '1.0.0',
     'description': 'Broken lists test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'brokenlistsrc',
@@ -153,7 +153,7 @@ beforeAll( async () => {
     } else {
         const globalConfig = {
             'envPath': NOLISTS_ENV,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': new Date().toISOString(),
             'sources': sourcesPayload
         }

--- a/tests/unit/spec-id-dispatch.test.mjs
+++ b/tests/unit/spec-id-dispatch.test.mjs
@@ -18,13 +18,13 @@ const PING_SCHEMA = `export const main = {
     namespace: 'demo',
     name: 'Demo Ping API',
     description: 'Demo schema for spec-id dispatch tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'demo', 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping endpoint',
@@ -40,13 +40,13 @@ const NFT_PART1_SCHEMA = `export const main = {
     namespace: 'moralis',
     name: 'NFT API Part 1',
     description: 'NFT schema part 1',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'nft', 'blockchain' ],
     root: 'https://deep-index.moralis.io/api/v2.2',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getNft: {
             method: 'GET',
             description: 'Get NFT',
@@ -62,13 +62,13 @@ const NFT_PART2_SCHEMA = `export const main = {
     namespace: 'moralis',
     name: 'NFT API Part 2',
     description: 'NFT schema part 2',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'nft', 'blockchain' ],
     root: 'https://deep-index.moralis.io/api/v2.2',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         getNftMetadata: {
             method: 'GET',
             description: 'Get NFT metadata',
@@ -91,7 +91,7 @@ const TEST_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {

--- a/tests/unit/status-and-config-deep-paths.test.mjs
+++ b/tests/unit/status-and-config-deep-paths.test.mjs
@@ -17,13 +17,13 @@ const schema = `export const main = {
     namespace: 'deepcfgsrc',
     name: 'Deep Config API',
     description: 'Schema for config tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -38,7 +38,7 @@ const registry = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Deep config test',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         { 'namespace': 'deepcfgsrc', 'file': 'simple.mjs', 'name': 'Deep Config API', 'requiredServerParams': [] }
     ]
@@ -63,7 +63,7 @@ beforeAll( async () => {
 
     const globalConfig = {
         'envPath': ENV_PATH,
-        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
         'initialized': new Date().toISOString(),
         'sources': { [SOURCE_NAME]: { 'type': 'local', 'schemaCount': 1 } }
     }

--- a/tests/unit/status-health.test.mjs
+++ b/tests/unit/status-health.test.mjs
@@ -17,13 +17,13 @@ const SCHEMA_CONTENT = `export const main = {
     namespace: 'healthTest',
     name: 'Health Test API',
     description: 'Schema for health check tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [ 'HEALTH_KEY' ],
     headers: {},
-    routes: {
+    tools: {
         check: { method: 'GET', description: 'Check', path: '/get', parameters: [] }
     }
 }
@@ -33,7 +33,7 @@ const TEST_REGISTRY = {
     'name': 'healthsrc',
     'version': '1.0.0',
     'description': 'Health test registry',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'healthTest',
@@ -81,7 +81,7 @@ describe( 'FlowMcpCli.status with full health checks', () => {
 
         const config = {
             'envPath': envPath,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': '2026-02-20T12:00:00.000Z',
             'sources': {
                 'healthsrc': { 'type': 'github', 'schemaCount': 1 }
@@ -125,7 +125,7 @@ describe( 'FlowMcpCli.status with full health checks', () => {
 
         const config = {
             'envPath': join( testCwd, 'nonexistent.env' ),
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': '2026-02-20T12:00:00.000Z'
         }
 
@@ -148,7 +148,7 @@ describe( 'FlowMcpCli.status with full health checks', () => {
 
         const config = {
             'envPath': envPath,
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': '2026-02-20T12:00:00.000Z'
         }
 
@@ -171,7 +171,7 @@ describe( 'FlowMcpCli.help', () => {
 
         const config = {
             'envPath': '/tmp/test.env',
-            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+            'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
             'initialized': '2026-02-20T12:00:00.000Z'
         }
 

--- a/tests/unit/test-method-deep-paths.test.mjs
+++ b/tests/unit/test-method-deep-paths.test.mjs
@@ -42,13 +42,13 @@ const SCHEMA_WITH_TESTS = `export const main = {
     namespace: 'deeptest',
     name: 'Deep Test API',
     description: 'Schema for deep test paths',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -64,7 +64,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Registry for deep path tests',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'deeptest',
@@ -81,7 +81,7 @@ const GLOBAL_CONFIG_WITH_ENV = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123def',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {
@@ -98,7 +98,7 @@ const GLOBAL_CONFIG_MISSING_ENV = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123def',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {

--- a/tests/unit/test-route-filter-and-validate-catch.test.mjs
+++ b/tests/unit/test-route-filter-and-validate-catch.test.mjs
@@ -20,13 +20,13 @@ const SCHEMA_WITH_TESTS = `export const main = {
     namespace: 'routefilter',
     name: 'Route Filter API',
     description: 'Schema with tests for route filtering',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         pingRoute: {
             method: 'GET',
             description: 'Ping route with tests',
@@ -49,7 +49,7 @@ const SCHEMA_NO_ROUTES = `export const main = {
     namespace: 'routefilter_broken',
     name: 'Broken Schema',
     description: 'Schema that may trigger catch blocks',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
@@ -62,7 +62,7 @@ const REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Route filter test source',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'routefilter',
@@ -99,7 +99,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {

--- a/tests/unit/test-schema-path.test.mjs
+++ b/tests/unit/test-schema-path.test.mjs
@@ -28,13 +28,13 @@ const VALID_SCHEMA_CONTENT = `export const main = {
     namespace: 'testpath',
     name: 'Test Path API',
     description: 'Schema for test path tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -50,13 +50,13 @@ const ENV_REQUIRED_SCHEMA_CONTENT = `export const main = {
     namespace: 'testpathenv',
     name: 'Test Path Env API',
     description: 'Schema requiring env vars',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [ 'TEST_API_KEY' ],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -73,7 +73,7 @@ const VALID_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {
@@ -88,7 +88,7 @@ const VALID_REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Test source for test schema path',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': SOURCE_NAME,
@@ -103,7 +103,7 @@ const ENV_REQUIRED_REGISTRY = {
     'name': 'testsrcenv',
     'version': '1.0.0',
     'description': 'Test source requiring env vars',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': 'testsrcenv',

--- a/tests/unit/validate-and-schema-edge-paths.test.mjs
+++ b/tests/unit/validate-and-schema-edge-paths.test.mjs
@@ -24,7 +24,7 @@ beforeAll( async () => {
         'flowmcpCore': {
             'version': '2.0.0',
             'commit': 'abc123',
-            'schemaSpec': '2.0.0'
+            'schemaSpec': '4.0.0'
         },
         'initialized': new Date().toISOString(),
         'sources': {}
@@ -85,13 +85,13 @@ describe( 'FlowMcpCli.validate — single valid schema file via schemaPath', () 
     namespace: 'vedgesingle',
     name: 'VEdge Single API',
     description: 'Valid single schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -159,13 +159,13 @@ describe( 'FlowMcpCli.validate — directory with valid and no-main schema', () 
     namespace: 'vedgemix',
     name: 'VEdge Mix API',
     description: 'Valid schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -285,13 +285,13 @@ describe( 'FlowMcpCli.remove — tool not in active list', () => {
     namespace: 'vedgerem',
     name: 'VEdge Remove API',
     description: 'Schema for remove test',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -306,7 +306,7 @@ describe( 'FlowMcpCli.remove — tool not in active list', () => {
             'name': SOURCE_NAME,
             'version': '1.0.0',
             'description': 'VEdge Remove source',
-            'schemaSpec': '2.0.0',
+            'schemaSpec': '4.0.0',
             'schemas': [
                 { 'namespace': 'vedgerem', 'file': 'rem.mjs', 'name': 'VEdge Remove API', 'requiredServerParams': [] }
             ]

--- a/tests/unit/validate-extended.test.mjs
+++ b/tests/unit/validate-extended.test.mjs
@@ -19,13 +19,13 @@ const VALID_SCHEMA = `export const main = {
     namespace: 'validateext',
     name: 'Validate Test API',
     description: 'Schema for validate tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [ 'https://docs.example.com' ],
     tags: [ 'test' ],
     root: 'https://api.example.com',
     requiredServerParams: [],
     headers: { 'Accept': 'application/json' },
-    routes: {
+    tools: {
         getItems: {
             method: 'GET',
             description: 'Get items list',
@@ -68,12 +68,12 @@ const MINIMAL_SCHEMA = `export const main = {
     namespace: 'minimal',
     name: 'Minimal',
     description: 'Minimal schema',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [],
     root: 'https://example.com',
     requiredServerParams: [],
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -96,7 +96,7 @@ beforeAll( async () => {
     await mkdir( GLOBAL_CONFIG_DIR, { recursive: true } )
     await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( {
         'envPath': '/tmp/test.env',
-        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '2.0.0' },
+        'flowmcpCore': { 'version': '2.0.0', 'commit': 'abc', 'schemaSpec': '4.0.0' },
         'initialized': '2026-02-20T12:00:00.000Z'
     }, null, 4 ), 'utf-8' )
 

--- a/tests/unit/validate-group-path.test.mjs
+++ b/tests/unit/validate-group-path.test.mjs
@@ -25,13 +25,13 @@ const VALID_SCHEMA_CONTENT = `export const main = {
     namespace: 'valsrc',
     name: 'Val Source API',
     description: 'Schema for validate group tests',
-    version: '2.0.0',
+    version: '4.0.0',
     docs: [],
     tags: [ 'test' ],
     root: 'https://httpbin.org',
     requiredServerParams: [],
     headers: {},
-    routes: {
+    tools: {
         ping: {
             method: 'GET',
             description: 'Ping',
@@ -46,7 +46,7 @@ const VALID_REGISTRY = {
     'name': SOURCE_NAME,
     'version': '1.0.0',
     'description': 'Test source for validate group path',
-    'schemaSpec': '2.0.0',
+    'schemaSpec': '4.0.0',
     'schemas': [
         {
             'namespace': SOURCE_NAME,
@@ -62,7 +62,7 @@ const VALID_GLOBAL_CONFIG = {
     'flowmcpCore': {
         'version': '2.0.0',
         'commit': 'abc123',
-        'schemaSpec': '2.0.0'
+        'schemaSpec': '4.0.0'
     },
     'initialized': '2026-02-20T12:00:00.000Z',
     'sources': {


### PR DESCRIPTION
Closes #36

## Summary
Makes `flowmcp call` (and add/validate/list) work for v4 schemas (`main.tools`), which were previously unreachable because the CLI only read `main.routes` (v2). Also fixes a misplaced shebang that crashed the CLI, and migrates the v2 test fixtures to v4.

## Changes
- **index.mjs**: shebang moved to line 1 (was line 12 → SyntaxError).
- **FlowMcpCli.mjs**: read `routes || tools` at all 8 call/add/validate spots; `#filterMainRoutes` now preserves the original key (root cause — it stripped v4 tools during group build).
- **tests**: new `calltool-v4-tools` regression test; 36 v2 fixtures migrated to v4. Migration safety-net (migrate-config/-command, valid-v2-*) intentionally kept on v2.

## Verification
- `npm test` → **715/715 tests, 71/71 suites pass**.
- Live `call` of Moralis erc20 price returns real data (WETH ~$2127); old code crashed with SyntaxError.

## Note
`routes || tools` is kept as a defensive migration bridge; full v2 removal is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)