### PR TITLE
Memo 085: CLI grading area + configurable island + github dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,17 +236,17 @@ source/file.mjs::routeName   # Single tool from a schema
 
 ## Add-ons
 
-### Konzept
+### Concept
 
-Add-ons sind formatspezifische Adapter, die FlowMCP-CLI bei Bedarf laedt, wenn ein Schema eine Resource mit einem nicht-trivialen Datenformat deklariert. Sie kapseln Wissen, das nicht in die Schema-Definition gehoert — etwa wie eine bestimmte SQLite-DB aufgebaut sein muss, welche Auto-Tools daraus ableitbar sind, oder wie eine Qualitaets-Garantie (Seal) zu pruefen ist.
+Add-ons are format-specific adapters that the FlowMCP CLI loads on demand when a schema declares a resource with a non-trivial data format. They encapsulate knowledge that does not belong in the schema definition — such as how a particular SQLite database must be structured, which auto-tools can be derived from it, or how a quality guarantee (seal) is verified.
 
-Add-ons leben als eigenstaendige GitHub-Repos, nicht als Teil der CLI. Das trennt Schema-Logik (Was wird abgefragt?) von Format-Logik (Wie ist das Format aufgebaut?) und erlaubt parallele Weiterentwicklung. Die CLI laedt Add-ons via `github:`-Shorthand on-demand, sobald ein Schema sie referenziert.
+Add-ons live as standalone GitHub repositories, not as part of the CLI. This separates schema logic (what is being queried?) from format logic (how is the format structured?) and allows both to evolve independently. The CLI loads add-ons via the `github:` shorthand on demand, as soon as a schema references them.
 
-Das Versprechen: ein Schema, das auf ein Add-on zeigt, bekommt automatisch generierte Tools auf einer Datenquelle, die der Add-on als spec-konform und qualitaetsgesichert verifiziert hat. Der Schema-Autor schreibt keinen SQL-Code, der Add-on-Autor keinen Schema-Boilerplate.
+The promise: a schema that points to an add-on automatically gets generated tools on a data source that the add-on has verified as spec-compliant and quality-assured. The schema author writes no SQL code, and the add-on author writes no schema boilerplate.
 
-### Beispiel: sqlite-gtfs
+### Example: sqlite-gtfs
 
-Der erste Add-on ist [`gtfs-sqlite-toolkit`](https://github.com/FlowMCP/gtfs-sqlite-toolkit). Er konvertiert GTFS-Schedule-Feeds (CSV in ZIP) in spec-konforme SQLite-Datenbanken und liefert dazu eine Capability-basierte Auto-Tool-Generierung. Ein Schema referenziert ihn so:
+The first add-on is [`gtfs-sqlite-toolkit`](https://github.com/FlowMCP/gtfs-sqlite-toolkit). It converts GTFS Schedule feeds (CSV in ZIP) into spec-compliant SQLite databases and provides capability-based auto-tool generation. A schema references it like this:
 
 ```javascript
 export const schema = {
@@ -267,11 +267,11 @@ export const schema = {
 }
 ```
 
-`source: 'sqlite-gtfs'` signalisiert der CLI, dass ein Add-on noetig ist. `addon` benennt das Repo, `addonSource` zeigt auf den Bezugsort (immer `github:<org>/<repo>` — keine npm-Registry). `${FLOWMCP_RESOURCES}` ist eine Pfad-Variable (siehe naechsten Abschnitt) und entspricht dem Default `~/.flowmcp/resources/`.
+`source: 'sqlite-gtfs'` signals to the CLI that an add-on is required. `addon` names the repository, `addonSource` points to its location (always `github:<org>/<repo>` — no npm registry). `${FLOWMCP_RESOURCES}` is a path variable (see the next section) and resolves to the default `~/.flowmcp/resources/`.
 
 ### Discovery: ADDON_REGISTRY
 
-Die CLI haelt einen kleinen, in `src/data/addons.mjs` **hardcoded** in V1 gepflegten Registry-Eintrag pro bekanntem `source`-Typ. Ein Eintrag besteht aus drei Feldern:
+The CLI keeps one registry entry per known `source` type, **hardcoded** in `src/data/addons.mjs` in V1. Each entry has three fields:
 
 ```javascript
 export const ADDON_REGISTRY = {
@@ -283,117 +283,117 @@ export const ADDON_REGISTRY = {
 }
 ```
 
-`name` ist der Add-on-Bezeichner (muss mit `addon` im Schema uebereinstimmen), `source` ist der `github:`-Bezugsort, `defaultVersion` ist der Git-Ref, der genutzt wird, wenn das Schema keinen `addonVersion` setzt. In V1 ist die Registry hardcoded; spaetere Versionen koennen sie ueber externe Quellen erweitern.
+`name` is the add-on identifier (must match `addon` in the schema), `source` is the `github:` location, and `defaultVersion` is the Git ref used when the schema does not set an `addonVersion`. In V1 the registry is hardcoded; later versions may extend it from external sources.
 
-Spec-Referenz: [`flowmcp-spec/spec/v4.0.0/13-resources.md`](../flowmcp-spec/spec/v4.0.0/13-resources.md) Abschnitt "SQLite-GTFS Resources".
+Spec reference: [`flowmcp-spec/spec/v4.0.0/13-resources.md`](../flowmcp-spec/spec/v4.0.0/13-resources.md), section "SQLite-GTFS Resources".
 
-Verwandte Abschnitte: [Pfad-Variablen](#pfad-variablen) (`${FLOWMCP_RESOURCES}`), [FlowMCP-Verzeichnis-Struktur](#flowmcp-verzeichnis-struktur) (Default-Ort `~/.flowmcp/resources/`), [Datenquellen — User-Verantwortung](#datenquellen--user-verantwortung) (DBs werden vom User selbst angelegt).
+Related sections: [Path Variables](#path-variables) (`${FLOWMCP_RESOURCES}`), [FlowMCP Directory Structure](#flowmcp-directory-structure) (default location `~/.flowmcp/resources/`), [Data Sources — User Responsibility](#data-sources--user-responsibility) (databases are created by the user).
 
-## Pfad-Variablen
+## Path Variables
 
-Pfad-Variablen erlauben User-Konfigurierbarkeit, ohne dass ein Schema fuer jeden Setup neu geschrieben werden muss. Sie tauchen typischerweise im `path`-Feld einer Schema-Resource auf — etwa um auf eine lokal abgelegte SQLite-DB zu zeigen, deren Ort der User selbst bestimmt.
+Path variables allow user configurability without rewriting a schema for every setup. They typically appear in the `path` field of a schema resource — for example, to point at a locally stored SQLite database whose location the user decides.
 
-Die CLI loest folgende Variablen auf:
+The CLI resolves the following variables:
 
-| Variable | Aufloesung | Default | Spec-Bezug |
+| Variable | Resolution | Default | Spec Reference |
 |----------|------------|---------|------------|
-| `${FLOWMCP_RESOURCES}` | Env-Var `FLOWMCP_RESOURCES` | `~/.flowmcp/resources/` | Spec-Primitive `main.resources` |
-| `${HOME}` | Env-Var `HOME` | obligatorisch (OS) | — |
-| `~` | Tilde-Expansion auf `$HOME` | obligatorisch (OS) | — |
+| `${FLOWMCP_RESOURCES}` | env var `FLOWMCP_RESOURCES` | `~/.flowmcp/resources/` | spec primitive `main.resources` |
+| `${HOME}` | env var `HOME` | required (OS) | — |
+| `~` | tilde expansion to `$HOME` | required (OS) | — |
 
-Die Aufloesung erfolgt in zwei Stufen: zuerst pruefen, ob die Env-Var gesetzt ist; wenn nicht, den dokumentierten Default einsetzen. Variablen ohne Default (wie `${HOME}`) muessen vom Betriebssystem bereitgestellt sein, sonst greift der Fehlerfall.
+Resolution happens in two steps: first check whether the env var is set; if not, fall back to the documented default. Variables without a default (such as `${HOME}`) must be provided by the operating system, otherwise the error case applies.
 
-### Fehler `RES035`
+### Error `RES035`
 
-Wenn die CLI eine Variable nicht aufloesen kann — etwa weil eine unbekannte Variable im `path` steht oder eine Env-Var ohne Default leer ist — bricht `flowmcp add` mit `RES035` ab. User beheben das, indem sie die Env-Var explizit setzen (`export FLOWMCP_RESOURCES=/path/to/dir`) oder die DB an den Default-Ort verschieben.
+When the CLI cannot resolve a variable — for example because an unknown variable appears in the `path`, or an env var without a default is empty — `flowmcp add` aborts with `RES035`. Users fix this by setting the env var explicitly (`export FLOWMCP_RESOURCES=/path/to/dir`) or by moving the database to the default location.
 
-### Namens-Familie `FLOWMCP_*`
+### The `FLOWMCP_*` Name Family
 
-Pfad-Variablen folgen dem Pattern Spec-Primitive-Name → Variablen-Name. `${FLOWMCP_RESOURCES}` bindet direkt an das Spec-Primitive `main.resources` und etabliert die `FLOWMCP_*`-Namensfamilie. Zukuenftige Erweiterungen sind absehbar — etwa `${FLOWMCP_LOGS}` fuer Log-Verzeichnisse oder `${FLOWMCP_CACHE}` als expliziter Cache-Hook. In V1 ist nur `${FLOWMCP_RESOURCES}` implementiert.
+Path variables follow the pattern spec-primitive name → variable name. `${FLOWMCP_RESOURCES}` binds directly to the spec primitive `main.resources` and establishes the `FLOWMCP_*` name family. Future extensions are foreseeable — such as `${FLOWMCP_LOGS}` for log directories or `${FLOWMCP_CACHE}` as an explicit cache hook. In V1 only `${FLOWMCP_RESOURCES}` is implemented.
 
-Beispiel fuer einen alternativen Ort:
+Example for an alternative location:
 
 ```bash
 export FLOWMCP_RESOURCES=/Volumes/MyData/flowmcp
 flowmcp add gtfsde-transit-v2
 ```
 
-Verwandte Abschnitte: [Add-ons](#add-ons) (Schema-Beispiele mit `${FLOWMCP_RESOURCES}`), [FlowMCP-Verzeichnis-Struktur](#flowmcp-verzeichnis-struktur) (Default-Aufloesung).
+Related sections: [Add-ons](#add-ons) (schema examples with `${FLOWMCP_RESOURCES}`), [FlowMCP Directory Structure](#flowmcp-directory-structure) (default resolution).
 
-## Datenquellen — User-Verantwortung
+## Data Sources — User Responsibility
 
-FlowMCP verteilt **keine** Provider-Daten in seinen oeffentlichen Repos. Das hat drei Gruende, die alle gleichzeitig gelten.
+FlowMCP distributes **no** provider data in its public repositories. There are three reasons, all of which apply at once.
 
-**Lizenz.** GTFS-Feeds und vergleichbare Provider-Datensaetze unterliegen jeweils eigenen Lizenz-Bedingungen — von CC BY 4.0 ueber custom EULAs bis zu Provider-spezifischen Klauseln. Wer die Daten in ein Public-Repo legt, verschiebt diese Konformitaets-Pflicht ungewollt auf das Repo und alle Forks. FlowMCP vermeidet das, indem die Daten beim User bleiben.
+**License.** GTFS feeds and comparable provider datasets are each subject to their own license terms — from CC BY 4.0 through custom EULAs to provider-specific clauses. Putting the data into a public repository unintentionally shifts this compliance obligation onto the repository and all its forks. FlowMCP avoids this by keeping the data with the user.
 
-**Skalierung.** Reale Provider-Feeds erreichen 40 MB und mehr (DB Bahn FV-Schedule liegt bei ~50 MB, regionale VBB-Feeds darueber). Solche Datenmengen im Git-History blaehen jedes Clone-Setup auf und machen den Repo schwerfaellig. Code und Daten gehoeren in unterschiedliche Lebenszyklen.
+**Scale.** Real provider feeds reach 40 MB and more (the DB Bahn FV schedule is around 50 MB, regional VBB feeds larger still). Such data volumes in the Git history bloat every clone and make the repository unwieldy. Code and data belong in different lifecycles.
 
-**Aktualitaet.** Feeds werden taeglich oder woechentlich aktualisiert. Ein Repo-State waere immer veraltet — der User muesste regelmaessig pruefen, ob die im Repo enthaltene Version noch der Realitaet entspricht. Sauberer ist es, wenn der User direkt vom Provider zieht und konvertiert.
+**Freshness.** Feeds are updated daily or weekly. A repository state would always be outdated — the user would have to check regularly whether the version bundled in the repository still matches reality. It is cleaner for the user to pull and convert directly from the provider.
 
-### User-Workflow
+### User Workflow
 
-Der Weg von einem Provider-Feed zu einer von FlowMCP nutzbaren DB hat vier Schritte:
+The path from a provider feed to a database usable by FlowMCP has four steps:
 
-1. **Download** des GTFS-Feeds vom Provider (Beispiele: `gtfs.de/de/feeds/`, regionale Open-Data-Portale, Provider-eigene Download-Seiten)
-2. **Konvertierung** via Add-on `gtfs-sqlite-toolkit` (siehe Add-on-README fuer den genauen Aufruf)
-3. **Ablage** der DB unter `${FLOWMCP_RESOURCES}/<name>.db` (Default `~/.flowmcp/resources/<name>.db`)
-4. **Aktivierung** via `flowmcp add <schema>`
+1. **Download** the GTFS feed from the provider (examples: `gtfs.de/de/feeds/`, regional open-data portals, provider-owned download pages)
+2. **Convert** via the `gtfs-sqlite-toolkit` add-on (see the add-on README for the exact invocation)
+3. **Store** the database at `${FLOWMCP_RESOURCES}/<name>.db` (default `~/.flowmcp/resources/<name>.db`)
+4. **Activate** via `flowmcp add <schema>`
 
-Konkrete Befehlsbeispiele:
+Concrete command examples:
 
 ```bash
-# 1. GTFS-Feed laden (Beispiel)
+# 1. Download the GTFS feed (example)
 curl -O https://download.gtfs.de/germany/free/latest.zip
 
-# 2. Konvertieren via Add-on (siehe gtfs-sqlite-toolkit README)
+# 2. Convert via the add-on (see gtfs-sqlite-toolkit README)
 cd ~/code/gtfs-sqlite-toolkit
 node convert.mjs --input=~/Downloads/latest.zip --output=~/.flowmcp/resources/gtfs-de.db
 
-# 3. Optional: DB an anderen Ort verschieben
-#    (wenn ${FLOWMCP_RESOURCES} nicht auf den Default zeigt)
+# 3. Optional: move the database to a different location
+#    (when ${FLOWMCP_RESOURCES} does not point at the default)
 
-# 4. Schema aktivieren
+# 4. Activate the schema
 flowmcp add gtfsde-transit-v2
 ```
 
-### Pre-Push-Schutz
+### Pre-Push Protection
 
-Das Add-on-Repo (`gtfs-sqlite-toolkit`) liefert ein Verifikations-Skript `scripts/check-no-provider-data.sh`, das vor jedem Commit bzw. Push grosse oder provider-spezifische Dateien erkennt und den Push abbricht. Diese Policy gilt auch fuer User-Forks — wer mitarbeitet, sollte das Skript in eigene Pre-Push-Hooks einbinden.
+The add-on repository (`gtfs-sqlite-toolkit`) ships a verification script `scripts/check-no-provider-data.sh` that detects large or provider-specific files before each commit or push and aborts the push. This policy also applies to user forks — contributors should wire the script into their own pre-push hooks.
 
-Wer ein Schema fuer einen neuen Provider beitragen moechte, liefert **nur das Schema und die Pfad-Variable** — niemals den Feed selbst.
+Anyone contributing a schema for a new provider supplies **only the schema and the path variable** — never the feed itself.
 
-Verwandte Abschnitte: [Pfad-Variablen](#pfad-variablen) (Schritt 3 nutzt `${FLOWMCP_RESOURCES}`), [FlowMCP-Verzeichnis-Struktur](#flowmcp-verzeichnis-struktur) (Default-Ablage-Ort), [Add-ons](#add-ons) (Schritt 2 erfordert ein Add-on).
+Related sections: [Path Variables](#path-variables) (step 3 uses `${FLOWMCP_RESOURCES}`), [FlowMCP Directory Structure](#flowmcp-directory-structure) (default storage location), [Add-ons](#add-ons) (step 2 requires an add-on).
 
-## FlowMCP-Verzeichnis-Struktur
+## FlowMCP Directory Structure
 
-FlowMCP nutzt ein zentrales User-Verzeichnis `~/.flowmcp/`, das ueber alle Projekte hinweg konsistent ist. Es haelt API-Keys, Cache und User-Resources an einem Ort — projekt-lokal koennen einzelne Werte ueberschrieben werden, der Default-Lookup bleibt zentral.
+FlowMCP uses a central user directory `~/.flowmcp/` that stays consistent across all projects. It holds API keys, cache, and user resources in one place — individual values can be overridden per project, while the default lookup stays central.
 
 ```
 ~/.flowmcp/
 ├── .env             ← API Keys (Single Source of Truth)
 ├── cache/           ← Schema cache (CLI-managed)
-└── resources/       ← User DBs (NEW — Default fuer ${FLOWMCP_RESOURCES}, ab Memo 051)
+└── resources/       ← User DBs (default for ${FLOWMCP_RESOURCES})
 ```
 
-| Pfad | Zweck | Verwaltung | Quer-Verweis |
+| Path | Purpose | Managed By | Cross-Reference |
 |------|-------|------------|--------------|
-| `~/.flowmcp/.env` | API Keys, Provider-Credentials | User (manuell) | Memo 032 Credentials Management |
-| `~/.flowmcp/cache/` | Schema-Cache, Add-on-Cache | CLI (automatisch) | — |
-| `~/.flowmcp/resources/` | User-DBs (z.B. konvertierte GTFS) | User (manuell oder via Add-on) | `${FLOWMCP_RESOURCES}` Default |
+| `~/.flowmcp/.env` | API keys, provider credentials | user (manual) | see the `.env` section below |
+| `~/.flowmcp/cache/` | schema cache, add-on cache | CLI (automatic) | — |
+| `~/.flowmcp/resources/` | user databases (e.g. converted GTFS) | user (manual or via add-on) | `${FLOWMCP_RESOURCES}` default |
 
 ### `.env` — Single Source of Truth
 
-Die globale `~/.flowmcp/.env` ist die Single Source of Truth fuer API-Keys aller FlowMCP-Tools. Sie wird vom User manuell gepflegt; die CLI legt sie nie automatisch an und ueberschreibt nie. Projekt-lokal kann ein Override unter `projects/<name>/.flowmcp/.env` abgelegt werden — der Lookup-Pfad ist erst projekt-lokal, dann global (siehe Memo 032 fuer das Credential-Modell).
+The global `~/.flowmcp/.env` is the single source of truth for the API keys of all FlowMCP tools. It is maintained manually by the user; the CLI never creates it automatically and never overwrites it. A project-local override can be placed at `projects/<name>/.flowmcp/.env` — the lookup path is project-local first, then global.
 
-### `resources/` — Default fuer `${FLOWMCP_RESOURCES}`
+### `resources/` — Default for `${FLOWMCP_RESOURCES}`
 
-Das Verzeichnis `~/.flowmcp/resources/` ist mit Memo 051 hinzugekommen und dient als Default-Aufloesung fuer die Pfad-Variable `${FLOWMCP_RESOURCES}`. User koennen die Env-Var auf einen anderen Ort setzen — etwa eine externe Festplatte oder ein zentrales Datenlaufwerk — die CLI loest dann dynamisch dorthin auf.
+The directory `~/.flowmcp/resources/` is the default resolution for the path variable `${FLOWMCP_RESOURCES}`. Users can set the env var to a different location — such as an external drive or a central data volume — and the CLI then resolves dynamically to that location.
 
 ```bash
 export FLOWMCP_RESOURCES=/Volumes/MyData/flowmcp
 ```
 
-Verwandte Abschnitte: [Pfad-Variablen](#pfad-variablen) (Aufloesungs-Logik), [Datenquellen — User-Verantwortung](#datenquellen--user-verantwortung) (warum die DBs hier landen, nicht im Repo).
+Related sections: [Path Variables](#path-variables) (resolution logic), [Data Sources — User Responsibility](#data-sources--user-responsibility) (why the databases live here, not in the repository).
 
 ## Global Flags
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npx flowmcp init
 | `flowmcp test user [--route name]` | Test all user schemas with live API calls |
 | `flowmcp test single <path> [--route name]` | Test a single schema file |
 
-### Grading (Memo 036)
+### Schema Grade Report
 
 `flowmcp dev grade` follows a 2-phase file-mode workflow (no API key required — harness produces scores).
 
@@ -111,6 +111,82 @@ For end-to-end grading (wraps both phases + Subagent scoring), use the workbench
 ```
 
 Spec: `flowmcp-spec/spec/v4.0.0/22-scoring-protocol.md`.
+
+### Grading
+
+The `grading` commands run the production grading system (v2) against a local
+workbench island under `grading-data/`. They are reachable both as
+`flowmcp grading ...` and `flowmcp dev grading ...` (the `dev` prefix is optional).
+
+| Command | Description |
+|---------|-------------|
+| `flowmcp grading import <provider-path>` | Import a provider folder into the island (Stage 0) |
+| `flowmcp grading run <ns\|selection> --emit-prompts` | Stage 1: deterministic pretest + emit grading prompts (handoff) |
+| `flowmcp grading run <ns\|selection> --consume-scores <path>` | Stage 3: consume harness scores, rebuild index, finalize |
+| `flowmcp grading export <ns\|selection>` | Export the graded state (`index.json`) back to the source |
+| `flowmcp grading state <ns\|selection>` | Show the current rollup status (read-only) |
+
+Flags for `run`: `--phase <area>` restricts grading to a single area/skill;
+`--on-conflict <abort\|skip\|overwrite>` sets the write-conflict policy
+(default: no overwrite).
+
+#### Stage model
+
+Grading runs in four stages. The CLI owns Stages 0, 1 and 3; the **harness**
+(your Claude Code agent loop) owns Stage 2.
+
+| Stage | Owner | What happens |
+|-------|-------|--------------|
+| 0 — Intake | CLI | `grading import` validates the provider schemas, snapshots them into the island and normalizes resources/skills |
+| 1 — Deterministic | CLI | `grading run --emit-prompts` runs the deterministic pretest (live HTTP checks — the request is never persisted) and the deterministic graders, then emits `prompts.json` + `state.json` for the handoff |
+| 2 — Non-deterministic | Harness | The agent loop reads `prompts.json`/`state.json` and grades each area (`start-grade → evaluate → apply-improvement`) — this is the only stage outside the CLI |
+| 3 — Finalize | CLI | `grading run --consume-scores <path>` reads the harness scores, computes grades, rebuilds `index.json` (5-status rollup) and finalizes the state for `export` |
+
+#### Flow auto-detection
+
+The target's path decides the test flow, the tier, and the maximum reachable grade:
+
+- `providers/<target>/` → **provider test** — tier `autonomous`, max **grade B**.
+- `selections/<target>/` → **selection test** — tier `group-bound`, **grade A** reachable.
+- A target that exists under both `providers/` and `selections/` is rejected with
+  an error and a fix hint; pass an explicit path to disambiguate.
+
+#### Handoff to the harness
+
+`grading run --emit-prompts` does not grade non-deterministically itself. It
+writes:
+
+- `prompts.json` — one grading prompt per area, each carrying a Goal-Block.
+- `state.json` — the run baton (which areas are pending/done), updated atomically
+  and never overwritten.
+
+The harness then drives the non-deterministic loop: an `Agent()` runs each
+area's grading prompt against the goal. A small fast evaluator (Haiku) reads
+**only the transcript** — it calls no tools — to decide when the goal is met.
+For this to work, the loop surfaces its progress into the transcript with
+`[GRADING]` lines, for example:
+
+```
+[GRADING] area=single-test/getFirstPrice schema-valid=ok status=graded written=ok
+[GRADING] PROGRESS 7/12
+[GRADING] DONE
+```
+
+When the goal is reached, hand the scores back to the CLI:
+
+```bash
+# Stage 1 — deterministic pretest + emit prompts (provider test)
+flowmcp grading run providers/defillama --emit-prompts
+
+# Stage 2 — harness grades each area (outside the CLI), writing scores
+
+# Stage 3 — consume the harness scores, rebuild the index, finalize
+flowmcp grading run providers/defillama --consume-scores scores.json
+
+# Inspect the rollup, then export the graded state back to the source
+flowmcp grading state providers/defillama
+flowmcp grading export providers/defillama
+```
 
 ### Agent Management
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Spec: `flowmcp-spec/spec/v4.0.0/22-scoring-protocol.md`.
 
 ### Grading
 
-The `grading` commands run the production grading system (v2) against a local
-workbench island under `grading-data/`. They are reachable both as
-`flowmcp grading ...` and `flowmcp dev grading ...` (the `dev` prefix is optional).
+The `grading` commands run the production grading system (v2) against a
+workbench island. They are reachable both as `flowmcp grading ...` and
+`flowmcp dev grading ...` (the `dev` prefix is optional).
 
 | Command | Description |
 |---------|-------------|
@@ -126,9 +126,29 @@ workbench island under `grading-data/`. They are reachable both as
 | `flowmcp grading export <ns\|selection>` | Export the graded state (`index.json`) back to the source |
 | `flowmcp grading state <ns\|selection>` | Show the current rollup status (read-only) |
 
-Flags for `run`: `--phase <area>` restricts grading to a single area/skill;
+Flags: `--phase <area>` restricts grading to a single area/skill;
 `--on-conflict <abort\|skip\|overwrite>` sets the write-conflict policy
-(default: no overwrite).
+(default: no overwrite); `--grading-data <path>` overrides the island location
+for a single call.
+
+#### Island location
+
+The grading island defaults to `~/.flowmcp/grading` (alongside the global
+`~/.flowmcp/.env` and `config.json` — the single source of truth). Resolution
+order (all explicit, no silent fallback):
+
+1. `--grading-data <path>` flag (resolved against the current directory)
+2. `FLOWMCP_GRADING_DATA` env var (resolved against the current directory)
+3. `"gradingDataDir"` in `~/.flowmcp/config.json` (resolved against `~/.flowmcp`)
+4. default `~/.flowmcp/grading`
+
+To set a persistent custom location, add to `~/.flowmcp/config.json`:
+
+```json
+{ "gradingDataDir": "grading" }
+```
+
+A relative value is resolved against `~/.flowmcp`; an absolute value is used as-is.
 
 #### Stage model
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "flowmcp-cli",
             "version": "0.1.0",
+            "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.0",
                 "better-sqlite3": "^12.6.2",
@@ -14,6 +15,7 @@
                 "ethers": "^6.16.0",
                 "figlet": "^1.10.0",
                 "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+                "flowmcp-grading": "file:../flowmcp-grading",
                 "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
                 "inquirer": "^12.3.0"
             },
@@ -26,6 +28,22 @@
             },
             "engines": {
                 "node": ">=22.0.0"
+            }
+        },
+        "../flowmcp-grading": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+                "js-yaml": "^3.14.2"
+            },
+            "devDependencies": {
+                "ajv": "^8.20.0",
+                "ajv-formats": "^3.0.1",
+                "jest": "^29.7.0"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@adraffy/ens-normalize": {
@@ -3526,6 +3544,10 @@
                 "flatted": "^3.3.3",
                 "zod": "^3.24.2"
             }
+        },
+        "node_modules/flowmcp-grading": {
+            "resolved": "../flowmcp-grading",
+            "link": true
         },
         "node_modules/flowmcp/node_modules/zod": {
             "version": "3.25.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "ethers": "^6.16.0",
                 "figlet": "^1.10.0",
                 "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
-                "flowmcp-grading": "file:../flowmcp-grading",
+                "flowmcp-grading": "github:FlowMCP/flowmcp-grading#e911958e91b75799b6efd78c99ebdbe5da103288",
                 "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
                 "inquirer": "^12.3.0"
             },
@@ -28,22 +28,6 @@
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "../flowmcp-grading": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
-                "js-yaml": "^3.14.2"
-            },
-            "devDependencies": {
-                "ajv": "^8.20.0",
-                "ajv-formats": "^3.0.1",
-                "jest": "^29.7.0"
-            },
-            "engines": {
-                "node": ">=22"
             }
         },
         "node_modules/@adraffy/ens-normalize": {
@@ -2275,7 +2259,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -3213,7 +3196,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -3546,8 +3528,17 @@
             }
         },
         "node_modules/flowmcp-grading": {
-            "resolved": "../flowmcp-grading",
-            "link": true
+            "version": "1.0.0",
+            "resolved": "git+ssh://git@github.com/FlowMCP/flowmcp-grading.git#e911958e91b75799b6efd78c99ebdbe5da103288",
+            "integrity": "sha512-HRhIGDRjJBlJHvTCHdqWzxte9nvY742Na3S0NPAqZP5vDbd1SdNyEPWBG2mJgryCCofZUIQK15z6ESVxVDWoYw==",
+            "license": "MIT",
+            "dependencies": {
+                "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+                "js-yaml": "^3.14.2"
+            },
+            "engines": {
+                "node": ">=22"
+            }
         },
         "node_modules/flowmcp/node_modules/zod": {
             "version": "3.25.76",
@@ -5213,7 +5204,6 @@
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
             "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -6390,7 +6380,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "ethers": "^6.16.0",
         "figlet": "^1.10.0",
         "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+        "flowmcp-grading": "file:../flowmcp-grading",
         "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
         "inquirer": "^12.3.0"
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "ethers": "^6.16.0",
         "figlet": "^1.10.0",
         "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
-        "flowmcp-grading": "file:../flowmcp-grading",
+        "flowmcp-grading": "github:FlowMCP/flowmcp-grading#e911958e91b75799b6efd78c99ebdbe5da103288",
         "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
         "inquirer": "^12.3.0"
     },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,7 +51,8 @@ const args = parseArgs( {
         'schema': { type: 'string' },
         'only': { type: 'string' },
         'phase': { type: 'string' },
-        'member-source': { type: 'string' }
+        'member-source': { type: 'string' },
+        'grading-data': { type: 'string' }
     }
 } )
 
@@ -534,31 +535,32 @@ const runCommand = async () => {
         const consumeScores = values[ 'consume-scores' ] === undefined ? null : values[ 'consume-scores' ]
         const onConflict = values[ 'on-conflict' ] === undefined ? null : values[ 'on-conflict' ]
         const memberSource = values[ 'member-source' ] === undefined ? null : values[ 'member-source' ]
+        const gradingDataDir = values[ 'grading-data' ] === undefined ? null : values[ 'grading-data' ]
         const json = values[ 'json' ] === true
 
         if( subCommand === 'import' ) {
-            const { result } = await FlowMcpCli.gradingImport( { cwd, 'path': target, onConflict, json } )
+            const { result } = await FlowMcpCli.gradingImport( { cwd, 'path': target, onConflict, gradingDataDir, json } )
             output( { result } )
 
             return true
         }
 
         if( subCommand === 'export' ) {
-            const { result } = await FlowMcpCli.gradingExport( { cwd, target, onConflict, json } )
+            const { result } = await FlowMcpCli.gradingExport( { cwd, target, onConflict, gradingDataDir, json } )
             output( { result } )
 
             return true
         }
 
         if( subCommand === 'run' ) {
-            const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, json } )
+            const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, gradingDataDir, json } )
             output( { result } )
 
             return true
         }
 
         if( subCommand === 'state' ) {
-            const { result } = await FlowMcpCli.gradingState( { cwd, target, json } )
+            const { result } = await FlowMcpCli.gradingState( { cwd, target, gradingDataDir, json } )
             output( { result } )
 
             return true

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -49,7 +49,8 @@ const args = parseArgs( {
         'key': { type: 'string' },
         'mode': { type: 'string' },
         'schema': { type: 'string' },
-        'only': { type: 'string' }
+        'only': { type: 'string' },
+        'phase': { type: 'string' }
     }
 } )
 
@@ -507,6 +508,59 @@ const runCommand = async () => {
             outputDir
         } )
         output( { result } )
+
+        return true
+    }
+
+    if( command === 'grading' ) {
+        const subCommand = positionals[ 1 ]
+        const validSubCommands = [ 'import', 'export', 'run', 'state' ]
+
+        if( !subCommand || !validSubCommands.includes( subCommand ) ) {
+            const result = {
+                'status': false,
+                'error': 'Missing or unknown grading sub-command.',
+                'fix': `Use: ${appConfig[ 'cliCommand' ]} grading import <provider-path> | export <ns|selection> | run <ns|selection> | state <ns|selection>`
+            }
+            output( { result } )
+
+            return true
+        }
+
+        const target = positionals[ 2 ]
+        const phase = values[ 'phase' ] || null
+        const emitPrompts = values[ 'emit-prompts' ] || false
+        const consumeScores = values[ 'consume-scores' ] || null
+        const onConflict = values[ 'on-conflict' ] || null
+        const json = values[ 'json' ] || false
+
+        if( subCommand === 'import' ) {
+            const { result } = await FlowMcpCli.gradingImport( { cwd, 'path': target, onConflict, json } )
+            output( { result } )
+
+            return true
+        }
+
+        if( subCommand === 'export' ) {
+            const { result } = await FlowMcpCli.gradingExport( { cwd, target, onConflict, json } )
+            output( { result } )
+
+            return true
+        }
+
+        if( subCommand === 'run' ) {
+            const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, json } )
+            output( { result } )
+
+            return true
+        }
+
+        if( subCommand === 'state' ) {
+            const { result } = await FlowMcpCli.gradingState( { cwd, target, json } )
+            output( { result } )
+
+            return true
+        }
 
         return true
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -50,7 +50,8 @@ const args = parseArgs( {
         'mode': { type: 'string' },
         'schema': { type: 'string' },
         'only': { type: 'string' },
-        'phase': { type: 'string' }
+        'phase': { type: 'string' },
+        'member-source': { type: 'string' }
     }
 } )
 
@@ -528,11 +529,12 @@ const runCommand = async () => {
         }
 
         const target = positionals[ 2 ]
-        const phase = values[ 'phase' ] || null
-        const emitPrompts = values[ 'emit-prompts' ] || false
-        const consumeScores = values[ 'consume-scores' ] || null
-        const onConflict = values[ 'on-conflict' ] || null
-        const json = values[ 'json' ] || false
+        const phase = values[ 'phase' ] === undefined ? null : values[ 'phase' ]
+        const emitPrompts = values[ 'emit-prompts' ] === true
+        const consumeScores = values[ 'consume-scores' ] === undefined ? null : values[ 'consume-scores' ]
+        const onConflict = values[ 'on-conflict' ] === undefined ? null : values[ 'on-conflict' ]
+        const memberSource = values[ 'member-source' ] === undefined ? null : values[ 'member-source' ]
+        const json = values[ 'json' ] === true
 
         if( subCommand === 'import' ) {
             const { result } = await FlowMcpCli.gradingImport( { cwd, 'path': target, onConflict, json } )
@@ -549,7 +551,7 @@ const runCommand = async () => {
         }
 
         if( subCommand === 'run' ) {
-            const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, json } )
+            const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, json } )
             output( { result } )
 
             return true

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -11944,58 +11944,564 @@ allowlist, migrate-config, etc.).
     }
 
 
-    // Stub methods — the actual logic (stages, harness handoff) is PRD-011.
-    // Dispatch (PRD-010) routes here; until PRD-011 fills these in, they return
-    // a clear "not implemented yet" result (no silent skip, no throw).
-    static async gradingImport( { cwd, path, onConflict, json } ) {
-        const grading = await FlowMcpCli.#loadGradingModule()
-        const result = {
-            'status': false,
-            'error': 'grading import is not implemented yet (PRD-011).',
-            'fix': 'Pending PRD-011.',
-            'moduleLoaded': grading !== null
+    // PRD-011 — the four grading methods realizing Stages 0/1/2/3.
+    // The CLI is the ONLY component with .env access (REV-14 Kap. 17): it
+    // resolves env + builds serverParams + loads the schema, then hands a flat
+    // { KEY:value } serverParams object to the grading module. The module reads
+    // no .env (G8). Stage 2 (non-deterministic grading) lives in the harness,
+    // NOT here — the CLI only emits the /goal handoff and later consumes scores.
+
+    static #gradingDataRoot( { cwd } ) {
+        return resolve( cwd, 'grading-data' )
+    }
+
+
+    // Build the live validate gate the grading module calls per schema during
+    // import. Reuses the CLI's structural validator (v4-aware). Signature:
+    //   ( { schema, sourcePath } ) -> { valid, errors }
+    // If the v4 module is unavailable we return null so the caller passes
+    // `undefined` to GradingImport.run — the module then falls back to its own
+    // in-module structural gate (no silent skip, an explicit fallback).
+    static async #buildGradingValidateGate() {
+        const v4 = await FlowMcpCli.#loadV4Module()
+        if( !v4 || !v4[ 'MainValidator' ] ) { return { gate: null } }
+
+        const gate = ( { schema, sourcePath } ) => {
+            const file = sourcePath === undefined ? 'unknown' : basename( sourcePath )
+            const checked = FlowMcpCli.#validateSingleSchema( { 'main': schema, file, v4 } )
+
+            return { 'valid': checked.status === true, 'errors': checked.messages === undefined ? [] : checked.messages }
         }
 
-        return { result }
+        return { gate }
+    }
+
+
+    // F29 flow detection — provider vs selection by which island tree holds the
+    // target. Ambiguity (in both / in neither) is a hard error with a copyable
+    // fix (an explicit path). No silent default.
+    static async #detectGradingFlow( { gradingDataRoot, target } ) {
+        const providerDir = join( gradingDataRoot, 'providers', target )
+        const selectionDir = join( gradingDataRoot, 'selections', target )
+        const inProvider = existsSync( providerDir )
+        const inSelection = existsSync( selectionDir )
+
+        if( inProvider === true && inSelection === true ) {
+            return {
+                'status': false,
+                'error': `Ambiguous target "${target}": exists in both providers/ and selections/.`,
+                'fix': `Pass an explicit path, e.g. ${join( 'providers', target )} or ${join( 'selections', target )}.`
+            }
+        }
+
+        if( inProvider === false && inSelection === false ) {
+            return {
+                'status': false,
+                'error': `Target "${target}" found in neither providers/ nor selections/.`,
+                'fix': `Run "grading import <provider-path>" first, or pass an explicit path under ${gradingDataRoot}.`
+            }
+        }
+
+        if( inProvider === true ) {
+            return { 'status': true, 'flow': 'provider', 'tier': 'autonomous', 'maxGrade': 'B', 'targetDir': providerDir }
+        }
+
+        return { 'status': true, 'flow': 'selection', 'tier': 'group-bound', 'maxGrade': 'A', 'targetDir': selectionDir }
+    }
+
+
+    // F16 Dependency-Resolver decision tree (implementation-plan N1, owned by
+    // the CLI). Branches:
+    //   (a) data missing + source exists  -> auto-chain Bereich 1 (import), then back
+    //   (b) quality < stable              -> report only (no silent downgrade)
+    //   (c) source missing                -> hard abort
+    // Downgrade only happens on explicit opt-in (not implemented as silent path).
+    // Returns { status, chain[], ... } — the chain is always logged into the result.
+    static async #resolveGradingDependencies( { gradingDataRoot, flow, target, targetDir, providerPath } ) {
+        const chain = []
+        const indexPath = join( targetDir, 'index.json' )
+        const hasIndex = existsSync( indexPath )
+
+        // (c) source missing — for a provider the source is the providerPath the
+        // user wants imported; for a selection the source is the selection folder
+        // itself. A missing targetDir is a hard abort (caught by F29 already), so
+        // here we only need the missing-source-for-auto-chain branch.
+        if( hasIndex === false ) {
+            if( flow === 'provider' && providerPath !== null && existsSync( providerPath ) === true ) {
+                // (a) data missing + source exists -> auto-chain Bereich 1 (import).
+                chain.push( { 'step': 'auto-chain-import', 'reason': 'index.json missing, provider source present', providerPath } )
+                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': providerPath, 'onConflict': null, 'json': true } )
+                if( imported.result.status !== true ) {
+                    return {
+                        'status': false,
+                        chain,
+                        'error': `Auto-chain import failed for ${providerPath}: ${( imported.result.errors || [ imported.result.error ] ).join( '; ' )}`,
+                        'fix': 'Fix the provider schemas, then re-run grading.'
+                    }
+                }
+                chain.push( { 'step': 'auto-chain-import', 'status': 'done' } )
+                return { 'status': true, chain }
+            }
+
+            // (c) source missing — hard abort.
+            return {
+                'status': false,
+                chain,
+                'error': `No index.json at ${indexPath} and no importable source available.`,
+                'fix': 'Run "grading import <provider-path>" to build the island before grading.'
+            }
+        }
+
+        // (b) quality < stable — report only. Read the rollup status; if it is
+        // below `stable` we surface it but do NOT block emit-prompts (the run is
+        // exactly how a target moves toward stable). The report is in the chain.
+        const { data: index } = await FlowMcpCli.#readJson( { 'filePath': indexPath } )
+        const rollup = index && index[ 'status' ] ? index[ 'status' ] : 'pending'
+        if( rollup !== 'stable' ) {
+            chain.push( { 'step': 'quality-report', 'rollupStatus': rollup, 'note': 'below stable — report only, no downgrade' } )
+        }
+
+        return { 'status': true, chain }
+    }
+
+
+    static async gradingImport( { cwd, path, onConflict, json } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        if( grading === null || grading[ 'GradingImport' ] === undefined ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
+        }
+
+        if( typeof path !== 'string' || path.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Missing provider path.', 'fix': 'Usage: flowmcp grading import <provider-path>' } ) }
+        }
+
+        const providerPath = resolve( cwd, path )
+        if( existsSync( providerPath ) === false ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `Provider path not found: ${providerPath}`, 'fix': 'Pass an existing provider folder containing schema .mjs files.' } ) }
+        }
+
+        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const { gate } = await FlowMcpCli.#buildGradingValidateGate()
+
+        const run = await grading[ 'GradingImport' ].run( {
+            providerPath,
+            gradingDataRoot,
+            'validateGate': gate === null ? undefined : gate
+        } )
+
+        if( run.status !== true ) {
+            return {
+                'result': {
+                    'status': false,
+                    'error': `Import failed: ${( run.errors || [] ).join( '; ' )}`,
+                    'fix': 'Fix the schema(s) reported above and re-run grading import.',
+                    'namespace': run.namespace,
+                    'errors': run.errors || []
+                }
+            }
+        }
+
+        return {
+            'result': {
+                'status': true,
+                'stage': 0,
+                'namespace': run.namespace,
+                'imported': run.imported,
+                'skipped': run.skipped,
+                'normalizedSkills': run.normalizedSkills,
+                'indexPath': run.indexPath,
+                'gateUsed': gate === null ? 'structural' : 'live-validate'
+            }
+        }
     }
 
 
     static async gradingExport( { cwd, target, onConflict, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
-        const result = {
-            'status': false,
-            'error': 'grading export is not implemented yet (PRD-011).',
-            'fix': 'Pending PRD-011.',
-            'moduleLoaded': grading !== null
+        if( grading === null || grading[ 'GradingExport' ] === undefined ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
         }
 
-        return { result }
+        if( typeof target !== 'string' || target.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Missing export target.', 'fix': 'Usage: flowmcp grading export <namespace|selection>' } ) }
+        }
+
+        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
+        if( detected.status !== true ) {
+            return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }
+        }
+
+        const stamp = new Date().toISOString().replace( /[:.]/g, '-' )
+        const exportDir = join( gradingDataRoot, '_exports', `${target.replace( /\//g, '_' )}--${stamp}` )
+
+        const run = await grading[ 'GradingExport' ].run( {
+            'target': detected.targetDir,
+            exportDir,
+            'includeSchemas': true
+        } )
+
+        if( run.status !== true ) {
+            return {
+                'result': {
+                    'status': false,
+                    'error': `Export failed: ${( run.errors || [] ).join( '; ' )}`,
+                    'fix': 'Resolve the export error above (a pre-existing export folder is never overwritten).',
+                    'errors': run.errors || []
+                }
+            }
+        }
+
+        return {
+            'result': {
+                'status': true,
+                'flow': run.flow,
+                'indexExportPath': run.indexExportPath,
+                'schemaExports': run.schemaExports,
+                exportDir
+            }
+        }
     }
 
 
     static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
-        const result = {
-            'status': false,
-            'error': 'grading run is not implemented yet (PRD-011).',
-            'fix': 'Pending PRD-011.',
-            'moduleLoaded': grading !== null
+        if( grading === null ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
         }
 
-        return { result }
+        if( typeof target !== 'string' || target.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Missing grading target.', 'fix': 'Usage: flowmcp grading run <namespace|selection> --emit-prompts | --consume-scores <path>' } ) }
+        }
+
+        // NO SILENT DEFAULT for the mode — exactly one of emit/consume.
+        if( emitPrompts !== true && ( consumeScores === null || consumeScores === undefined ) ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Mode required: --emit-prompts or --consume-scores <path>.', 'fix': 'Pick exactly one mode (2-phase grading, no default mode).' } ) }
+        }
+        if( emitPrompts === true && consumeScores !== null && consumeScores !== undefined ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Modes are mutually exclusive: pass either --emit-prompts or --consume-scores, not both.', 'fix': 'Run emit-prompts first, then consume-scores in a separate call.' } ) }
+        }
+
+        // NO SILENT DEFAULT for the conflict policy — explicit allowlist.
+        const conflict = onConflict === null || onConflict === undefined ? 'skip' : onConflict
+        const validConflicts = [ 'abort', 'skip', 'overwrite' ]
+        if( validConflicts.includes( conflict ) === false ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `Invalid --on-conflict value: ${conflict}`, 'fix': `Use one of: ${validConflicts.join( ', ' )}.` } ) }
+        }
+
+        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+
+        // F29 flow detection.
+        const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
+        if( detected.status !== true ) {
+            return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }
+        }
+
+        // F16 dependency resolver (auto-chain / report / abort). The chain is
+        // always returned in the result so the orchestration is auditable.
+        const deps = await FlowMcpCli.#resolveGradingDependencies( {
+            gradingDataRoot,
+            'flow': detected.flow,
+            target,
+            'targetDir': detected.targetDir,
+            'providerPath': null
+        } )
+        if( deps.status !== true ) {
+            return { 'result': { 'status': false, 'error': deps.error, 'fix': deps.fix, 'dependencyChain': deps.chain } }
+        }
+
+        // Selection flow: PreConditionCheck gate (PRE-004) before Stage 1.
+        if( detected.flow === 'selection' && grading[ 'PreConditionCheck' ] !== undefined ) {
+            const pre = await grading[ 'PreConditionCheck' ].check( { gradingDataRoot, 'selectionId': target } )
+            if( pre.passed !== true ) {
+                return {
+                    'result': {
+                        'status': false,
+                        'error': `Pre-condition not met: ${( pre.errors || [] ).join( '; ' )}`,
+                        'fix': 'Grade every member to `stable` first (no silent skip), then re-run the selection grading.',
+                        'blockedMembers': pre.blockedMembers,
+                        'dependencyChain': deps.chain
+                    }
+                }
+            }
+        }
+
+        if( emitPrompts === true ) {
+            return FlowMcpCli.#gradingEmitPrompts( { cwd, grading, gradingDataRoot, 'flow': detected.flow, 'tier': detected.tier, 'maxGrade': detected.maxGrade, 'targetDir': detected.targetDir, target, phase, conflict, 'dependencyChain': deps.chain } )
+        }
+
+        return FlowMcpCli.#gradingConsumeScores( { cwd, grading, gradingDataRoot, 'flow': detected.flow, 'targetDir': detected.targetDir, target, consumeScores, conflict, 'dependencyChain': deps.chain } )
+    }
+
+
+    // Stage 1 — deterministic: Phase-0/1 wiring -> DataPretest.run -> emit the
+    // /goal handoff (prompts.json + state.json baton). The CLI does NOT run
+    // Agent() — Stage 2 lives in the harness.
+    static async #gradingEmitPrompts( { cwd, grading, gradingDataRoot, flow, tier, maxGrade, targetDir, target, phase, conflict, dependencyChain } ) {
+        const namespace = basename( targetDir )
+        const promptsPath = join( targetDir, 'prompts.json' )
+        const statePath = join( targetDir, 'state.json' )
+
+        if( existsSync( promptsPath ) === true && conflict === 'abort' ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `NO-OVERWRITE conflict: ${promptsPath} already exists`, 'fix': 'Pass --on-conflict=skip to keep the existing handoff, or remove it deliberately.' } ) }
+        }
+        if( existsSync( promptsPath ) === true && conflict === 'skip' ) {
+            return { 'result': { 'status': true, 'stage': 1, 'mode': 'emit-prompts', 'skipped': true, promptsPath, statePath, dependencyChain } }
+        }
+
+        // Phase-0/1 wiring (REV-14 Kap. 15): resolveEnv -> buildServerParams ->
+        // loadSchema -> resolveSharedLists -> DataPretest.run directly. The CLI is
+        // the only component with .env access; serverParams are flat { KEY:value }.
+        const pretests = []
+        const schemaDirs = await FlowMcpCli.#listGradingSchemaDirs( { targetDir } )
+
+        await schemaDirs
+            .reduce( ( promise, schemaName ) => promise.then( async () => {
+                if( phase !== null && phase !== undefined && phase !== schemaName ) { return }
+
+                const snapshot = await FlowMcpCli.#resolveLatestSchemaSnapshot( { grading, targetDir, schemaName } )
+                if( snapshot === null ) {
+                    pretests.push( { schemaName, 'ok': false, 'errors': [ `no resolvable schema snapshot for ${schemaName}` ] } )
+                    return
+                }
+
+                const { main, handlersFn } = await FlowMcpCli.#loadSchema( { 'filePath': snapshot.path } )
+                if( !main ) {
+                    pretests.push( { schemaName, 'ok': false, 'errors': [ `cannot load schema snapshot: ${snapshot.path}` ] } )
+                    return
+                }
+
+                const { envObject } = await FlowMcpCli.#resolveEnv( { cwd } )
+                const requiredServerParams = Array.isArray( main[ 'requiredServerParams' ] ) ? main[ 'requiredServerParams' ] : []
+                const { serverParams } = FlowMcpCli.#buildServerParams( { envObject, requiredServerParams } )
+                const { sharedLists } = await FlowMcpCli.#resolveSharedListsForSchema( { main, 'filePath': snapshot.path } )
+
+                const pretest = await grading[ 'DataPretest' ].run( {
+                    namespace,
+                    'toolName': schemaName,
+                    main,
+                    handlersFn,
+                    'schemaSnapshotPath': snapshot.path,
+                    serverParams,
+                    sharedLists,
+                    'gradingDataDir': gradingDataRoot
+                } )
+
+                // F26: never persist serverParams or request payloads — only the
+                // schema name, ok-flag and summary path go into the handoff. Missing
+                // keys surface by NAME only (DPT-005), never as a value.
+                pretests.push( {
+                    schemaName,
+                    'ok': pretest.ok,
+                    'passedDownloadable': pretest.passedDownloadable,
+                    'required': pretest.required,
+                    'summaryPath': pretest.summaryPath,
+                    'errors': pretest.errors
+                } )
+            } ), Promise.resolve() )
+
+        // Goal-Block (PromptBuilder) — the completion condition + surfacing
+        // convention that drives the harness /goal loop (Stage 2).
+        const { goalBlock, condition, maxTurns } = grading[ 'PromptBuilder' ].buildGoalBlock( {
+            'condition': `Grade the ${flow} "${target}" (tier ${tier}, max grade ${maxGrade}) across all required areas until every area reaches a stable grade`,
+            'maxTurns': 25
+        } )
+
+        const now = new Date().toISOString()
+        const promptsDoc = {
+            target,
+            flow,
+            tier,
+            maxGrade,
+            namespace,
+            'scoringProtocol': 'v1',
+            'goal': { condition, maxTurns, goalBlock },
+            'pretests': pretests
+        }
+
+        const stateDoc = {
+            target,
+            flow,
+            tier,
+            'status': 'prompts-emitted',
+            'createdAt': now,
+            'lastUpdatedAt': now,
+            'phases': {
+                'promptsEmitted': now,
+                'scoresReceived': null,
+                'gradeComputed': null,
+                'indexRebuilt': null
+            },
+            dependencyChain
+        }
+
+        // Write-safety: atomic + No-Overwrite. prompts respects the explicit
+        // conflict policy; state is a one-time baton (skip if present).
+        const promptsWrite = await FlowMcpCli.#writeAtomic( { 'path': promptsPath, 'content': JSON.stringify( promptsDoc, null, 4 ), 'onConflict': conflict } )
+        await FlowMcpCli.#writeAtomic( { 'path': statePath, 'content': JSON.stringify( stateDoc, null, 4 ), 'onConflict': 'skip' } )
+
+        return {
+            'result': {
+                'status': true,
+                'stage': 1,
+                'mode': 'emit-prompts',
+                'skipped': promptsWrite.skipped === true,
+                flow,
+                tier,
+                maxGrade,
+                target,
+                promptsPath,
+                statePath,
+                'pretestCount': pretests.length,
+                dependencyChain
+            }
+        }
+    }
+
+
+    // Stage 3 — consume the harness scores -> grade -> rebuild*Index (5-status)
+    // -> finalize the state baton.
+    static async #gradingConsumeScores( { cwd, grading, gradingDataRoot, flow, targetDir, target, consumeScores, conflict, dependencyChain } ) {
+        const scoresPath = resolve( cwd, consumeScores )
+        if( existsSync( scoresPath ) === false ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `Scores file not found: ${scoresPath}`, 'fix': 'Pass the path written by the harness Stage 2.' } ) }
+        }
+
+        const { data: scoresDoc } = await FlowMcpCli.#readJson( { 'filePath': scoresPath } )
+        if( scoresDoc === null ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `Invalid JSON in scores file: ${scoresPath}`, 'fix': 'The harness must write valid JSON scores.' } ) }
+        }
+        if( Array.isArray( scoresDoc[ 'scores' ] ) === false ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Invalid scores format: "scores" must be an array.', 'fix': 'See the grading scores schema.' } ) }
+        }
+
+        // Rebuild the 5-status index from the resolved grade snapshots on disk.
+        let rebuilt = null
+        if( flow === 'provider' ) {
+            rebuilt = await grading[ 'RebuildIndex' ].rebuildNamespaceIndex( { 'namespaceDir': targetDir } )
+        } else {
+            rebuilt = await grading[ 'RebuildIndex' ].rebuildSelectionIndex( { 'selectionDir': targetDir, 'providersRoot': join( gradingDataRoot, 'providers' ) } )
+        }
+
+        if( rebuilt.status !== true ) {
+            return {
+                'result': {
+                    'status': false,
+                    'error': `Index rebuild failed: ${( rebuilt.errors || [] ).join( '; ' )}`,
+                    'fix': 'Resolve the index errors above and re-run consume-scores.',
+                    'errors': rebuilt.errors || [],
+                    dependencyChain
+                }
+            }
+        }
+
+        // Finalize the state baton (overwrite is the deliberate, named end-state).
+        const statePath = join( targetDir, 'state.json' )
+        const now = new Date().toISOString()
+        const { data: prevState } = await FlowMcpCli.#readJson( { 'filePath': statePath } )
+        const stateDoc = prevState === null
+            ? { target, flow, 'createdAt': now, 'phases': {} }
+            : prevState
+        stateDoc[ 'status' ] = 'graded'
+        stateDoc[ 'lastUpdatedAt' ] = now
+        stateDoc[ 'rollupStatus' ] = rebuilt.index[ 'status' ]
+        stateDoc[ 'rollupGrade' ] = rebuilt.index[ 'grade' ]
+        if( stateDoc[ 'phases' ] === undefined ) { stateDoc[ 'phases' ] = {} }
+        stateDoc[ 'phases' ][ 'scoresReceived' ] = now
+        stateDoc[ 'phases' ][ 'gradeComputed' ] = now
+        stateDoc[ 'phases' ][ 'indexRebuilt' ] = now
+        stateDoc[ 'dependencyChain' ] = dependencyChain
+
+        await FlowMcpCli.#writeGuarded( { 'path': statePath, 'content': JSON.stringify( stateDoc, null, 4 ), 'onExists': 'overwrite' } )
+
+        return {
+            'result': {
+                'status': true,
+                'stage': 3,
+                'mode': 'consume-scores',
+                flow,
+                target,
+                'rollupStatus': rebuilt.index[ 'status' ],
+                'rollupGrade': rebuilt.index[ 'grade' ],
+                'indexPath': rebuilt.indexPath,
+                'scoreCount': scoresDoc[ 'scores' ].length,
+                dependencyChain
+            }
+        }
+    }
+
+
+    // List the schema sub-folders of a provider/selection island (skip _gradings,
+    // _exports, resources, skills, selection and JSON files at the root).
+    static async #listGradingSchemaDirs( { targetDir } ) {
+        const reserved = [ '_gradings', '_exports', 'resources', 'skills', 'selection', 'tools' ]
+        let entries = []
+        try {
+            entries = await readdir( targetDir, { 'withFileTypes': true } )
+        } catch {
+            return []
+        }
+
+        const dirs = entries
+            .filter( ( entry ) => entry.isDirectory() === true )
+            .map( ( entry ) => entry.name )
+            .filter( ( name ) => name.startsWith( '_' ) === false )
+            .filter( ( name ) => reserved.includes( name ) === false )
+            .sort()
+
+        return dirs
+    }
+
+
+    // Resolve the newest schema snapshot for one island schema folder. The B2
+    // grammar puts the snapshot under <schemaName>/schema/<name>--<ts>--<hash>.mjs.
+    static async #resolveLatestSchemaSnapshot( { grading, targetDir, schemaName } ) {
+        const snapshotDir = join( targetDir, schemaName, 'schema' )
+        const resolved = await grading[ 'RebuildIndex' ].resolveLatest( { 'dir': snapshotDir, 'logicalName': schemaName } )
+        if( resolved.status !== true ) { return null }
+
+        return { 'path': resolved.path, 'file': resolved.file }
     }
 
 
     static async gradingState( { cwd, target, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
-        const result = {
-            'status': false,
-            'error': 'grading state is not implemented yet (PRD-011).',
-            'fix': 'Pending PRD-011.',
-            'moduleLoaded': grading !== null
+        if( grading === null ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
         }
 
-        return { result }
+        if( typeof target !== 'string' || target.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Missing state target.', 'fix': 'Usage: flowmcp grading state <namespace|selection>' } ) }
+        }
+
+        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
+        if( detected.status !== true ) {
+            return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }
+        }
+
+        const indexPath = join( detected.targetDir, 'index.json' )
+        const statePath = join( detected.targetDir, 'state.json' )
+        const { data: index } = await FlowMcpCli.#readJson( { 'filePath': indexPath } )
+        const { data: state } = await FlowMcpCli.#readJson( { 'filePath': statePath } )
+
+        return {
+            'result': {
+                'status': true,
+                'flow': detected.flow,
+                'tier': detected.tier,
+                target,
+                'rollupStatus': index === null ? null : index[ 'status' ],
+                'rollupGrade': index === null ? null : index[ 'grade' ],
+                'summary': index === null ? null : index[ 'summary' ],
+                'batonStatus': state === null ? null : state[ 'status' ],
+                'lastUpdatedAt': state === null ? null : state[ 'lastUpdatedAt' ],
+                indexPath,
+                statePath,
+                'indexPresent': index !== null,
+                'statePresent': state !== null
+            }
+        }
     }
 
 

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -10103,10 +10103,9 @@ allowlist, migrate-config, etc.).
 
 
     // Lazy-import for the grading module's public surface (flowmcp-grading/src/index.mjs).
-    // PRODUCTION PIN at push-time (package.json) MUST be:
-    //   "flowmcp-grading": "github:FlowMCP/flowmcp-grading#85c2f621bf0135cddc8e473dc71ebea4bd2fe95f"
-    // Currently pinned to "file:../flowmcp-grading" because the P3 grading work is committed
-    // LOCALLY but NOT yet pushed to GitHub — a github:#<sha> pin would fail to install.
+    // Pinned in package.json to a published commit:
+    //   "flowmcp-grading": "github:FlowMCP/flowmcp-grading#e911958e91b75799b6efd78c99ebdbe5da103288"
+    // (For local cross-repo development, swap to "file:../flowmcp-grading".)
     static async #loadGradingModule() {
         if( FlowMcpCli.#gradingOverride ) { return FlowMcpCli.#gradingOverride }
         try {

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -12054,6 +12054,28 @@ allowlist, migrate-config, etc.).
                 return { 'status': true, chain }
             }
 
+            if( flow === 'selection' && existsSync( targetDir ) === true ) {
+                // A selection is authored in-island: its source IS the selection
+                // folder. Build the derived index.json (rebuildSelectionIndex) on
+                // first run instead of aborting.
+                chain.push( { 'step': 'auto-build-selection-index', 'reason': 'index.json missing, selection folder present', targetDir } )
+                const grading = await FlowMcpCli.#loadGradingModule()
+                if( grading === null || grading[ 'RebuildIndex' ] === undefined ) {
+                    return { 'status': false, chain, 'error': 'grading module unavailable for selection index build', 'fix': 'npm install / update the flowmcp-grading dependency' }
+                }
+                const built = await grading[ 'RebuildIndex' ].rebuildSelectionIndex( { 'selectionDir': targetDir, 'providersRoot': join( gradingDataRoot, 'providers' ) } )
+                if( built.status !== true ) {
+                    return {
+                        'status': false,
+                        chain,
+                        'error': `Selection index build failed: ${( built.errors || [] ).join( '; ' )}`,
+                        'fix': 'Resolve the selection-index errors above and re-run grading.'
+                    }
+                }
+                chain.push( { 'step': 'auto-build-selection-index', 'status': 'done' } )
+                return { 'status': true, chain }
+            }
+
             // (c) source missing — hard abort.
             return {
                 'status': false,
@@ -12073,6 +12095,59 @@ allowlist, migrate-config, etc.).
         }
 
         return { 'status': true, chain }
+    }
+
+
+    // F16 case (a) for selection members: a member referenced by the selection but
+    // not yet imported into the island is auto-chained — its namespace is imported
+    // from the explicit `memberSource` providers root, then the selection index is
+    // rebuilt so the member resolves. No hidden default: without `memberSource` the
+    // missing members are only reported (the Pre-Condition gate then blocks).
+    static async #resolveMissingSelectionMembers( { cwd, grading, gradingDataRoot, targetDir, target, memberSource, chain } ) {
+        const indexPath = join( targetDir, 'index.json' )
+        const { data: index } = await FlowMcpCli.#readJson( { 'filePath': indexPath } )
+        if( index === null || index[ 'members' ] === undefined ) { return { 'status': true } }
+
+        const missing = Object.entries( index[ 'members' ] )
+            .filter( ( entry ) => entry[ 1 ] !== null && entry[ 1 ][ 'reason' ] === 'selection member, not imported' )
+            .map( ( entry ) => entry[ 0 ] )
+        if( missing.length === 0 ) { return { 'status': true } }
+
+        if( typeof memberSource !== 'string' || memberSource.length === 0 ) {
+            chain.push( { 'step': 'member-report', 'missingMembers': missing, 'note': 'members not imported; pass --member-source <providers-root> to auto-chain (no silent import)' } )
+            return { 'status': true }
+        }
+
+        const sourceRoot = resolve( cwd, memberSource )
+        const namespaces = [ ...new Set( missing.map( ( schemaId ) => schemaId.split( '.' )[ 0 ] ) ) ]
+
+        const importErrors = []
+        await namespaces
+            .reduce( ( promise, namespace ) => promise.then( async () => {
+                const nsPath = join( sourceRoot, namespace )
+                if( existsSync( nsPath ) === false ) {
+                    importErrors.push( `F16 case (c): source for namespace '${namespace}' not found under ${sourceRoot}` )
+                    return
+                }
+                chain.push( { 'step': 'member-auto-chain', 'namespace': namespace, 'reason': 'referenced selection member not imported, source present' } )
+                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': nsPath, 'onConflict': null, 'json': true } )
+                if( imported.result.status !== true ) {
+                    importErrors.push( `member auto-chain import failed for ${namespace}: ${( imported.result.errors || [ imported.result.error ] ).join( '; ' )}` )
+                    return
+                }
+                chain.push( { 'step': 'member-auto-chain', 'namespace': namespace, 'status': 'done' } )
+            } ), Promise.resolve() )
+
+        if( importErrors.length > 0 ) {
+            return { 'status': false, 'error': importErrors.join( '; ' ), 'fix': 'Provide a --member-source root containing the missing member namespaces, or import them manually.' }
+        }
+
+        // Rebuild the selection index so the freshly-imported members resolve.
+        const rebuilt = await grading[ 'RebuildIndex' ].rebuildSelectionIndex( { 'selectionDir': targetDir, 'providersRoot': join( gradingDataRoot, 'providers' ) } )
+        if( rebuilt.status !== true ) {
+            return { 'status': false, 'error': `Selection index rebuild after member auto-chain failed: ${( rebuilt.errors || [] ).join( '; ' )}`, 'fix': 'Inspect the imported members and re-run.' }
+        }
+        return { 'status': true }
     }
 
 
@@ -12175,7 +12250,7 @@ allowlist, migrate-config, etc.).
     }
 
 
-    static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, json } ) {
+    static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
         if( grading === null ) {
             return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
@@ -12219,6 +12294,16 @@ allowlist, migrate-config, etc.).
         } )
         if( deps.status !== true ) {
             return { 'result': { 'status': false, 'error': deps.error, 'fix': deps.fix, 'dependencyChain': deps.chain } }
+        }
+
+        // Selection flow: F16 case (a) member auto-chain, then PreConditionCheck.
+        if( detected.flow === 'selection' ) {
+            const resolvedMembers = await FlowMcpCli.#resolveMissingSelectionMembers( {
+                cwd, grading, gradingDataRoot, 'targetDir': detected.targetDir, target, memberSource, 'chain': deps.chain
+            } )
+            if( resolvedMembers.status !== true ) {
+                return { 'result': { 'status': false, 'error': resolvedMembers.error, 'fix': resolvedMembers.fix, 'dependencyChain': deps.chain } }
+            }
         }
 
         // Selection flow: PreConditionCheck gate (PRE-004) before Stage 1.

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -8218,9 +8218,12 @@ Grading (v2):
                                              Stage 3: consume harness scores, rebuild index, finalize
     --phase <area>                           Restrict grading to a single area / skill
     --on-conflict <abort|skip|overwrite>     Write-conflict policy (default: no-overwrite)
+    --grading-data <path>                    Override the island location for this call
   grading export <ns|selection>              Export graded state (index.json) back to the source
   grading state <ns|selection>               Show current rollup status (read-only)
   (also available as "${cmd} grading ..." — the "dev" prefix is optional)
+  Island default: ~/.flowmcp/grading (override via --grading-data,
+    FLOWMCP_GRADING_DATA, or "gradingDataDir" in ~/.flowmcp/config.json)
 
 Shared Lists (v4):
   dev lists list                             List all shared lists
@@ -11962,8 +11965,30 @@ allowlist, migrate-config, etc.).
     // no .env (G8). Stage 2 (non-deterministic grading) lives in the harness,
     // NOT here — the CLI only emits the /goal handoff and later consumes scores.
 
-    static #gradingDataRoot( { cwd } ) {
-        return resolve( cwd, 'grading-data' )
+    // Resolve the grading-data island root. Precedence (all explicit, no silent
+    // default):
+    //   1. --grading-data flag (per-call override, cwd-relative)
+    //   2. FLOWMCP_GRADING_DATA env var (cwd-relative / absolute)
+    //   3. "gradingDataDir" in the GLOBAL ~/.flowmcp/config.json (home-relative / absolute)
+    //   4. built-in default ~/.flowmcp/grading
+    // The global config + default live in the user home (single source of truth,
+    // same location as ~/.flowmcp/.env). In tests os.homedir() is mocked into the
+    // repo sandbox, so this never touches the real ~/.flowmcp.
+    static async #gradingDataRoot( { cwd, gradingDataDir } ) {
+        if( typeof gradingDataDir === 'string' && gradingDataDir.length > 0 ) {
+            return resolve( cwd, gradingDataDir )
+        }
+        const envDir = process.env[ 'FLOWMCP_GRADING_DATA' ]
+        if( typeof envDir === 'string' && envDir.length > 0 ) {
+            return resolve( cwd, envDir )
+        }
+        const home = homedir()
+        const globalConfigDir = join( home, appConfig[ 'globalConfigDirName' ] )
+        const { data: globalConfig } = await FlowMcpCli.#readJson( { 'filePath': join( globalConfigDir, 'config.json' ) } )
+        if( globalConfig !== null && typeof globalConfig[ 'gradingDataDir' ] === 'string' && globalConfig[ 'gradingDataDir' ].length > 0 ) {
+            return resolve( globalConfigDir, globalConfig[ 'gradingDataDir' ] )
+        }
+        return join( globalConfigDir, 'grading' )
     }
 
 
@@ -12041,7 +12066,7 @@ allowlist, migrate-config, etc.).
             if( flow === 'provider' && providerPath !== null && existsSync( providerPath ) === true ) {
                 // (a) data missing + source exists -> auto-chain Bereich 1 (import).
                 chain.push( { 'step': 'auto-chain-import', 'reason': 'index.json missing, provider source present', providerPath } )
-                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': providerPath, 'onConflict': null, 'json': true } )
+                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': providerPath, 'onConflict': null, 'gradingDataDir': basename( gradingDataRoot ), 'json': true } )
                 if( imported.result.status !== true ) {
                     return {
                         'status': false,
@@ -12130,7 +12155,7 @@ allowlist, migrate-config, etc.).
                     return
                 }
                 chain.push( { 'step': 'member-auto-chain', 'namespace': namespace, 'reason': 'referenced selection member not imported, source present' } )
-                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': nsPath, 'onConflict': null, 'json': true } )
+                const imported = await FlowMcpCli.gradingImport( { 'cwd': dirname( gradingDataRoot ), 'path': nsPath, 'onConflict': null, 'gradingDataDir': basename( gradingDataRoot ), 'json': true } )
                 if( imported.result.status !== true ) {
                     importErrors.push( `member auto-chain import failed for ${namespace}: ${( imported.result.errors || [ imported.result.error ] ).join( '; ' )}` )
                     return
@@ -12151,7 +12176,7 @@ allowlist, migrate-config, etc.).
     }
 
 
-    static async gradingImport( { cwd, path, onConflict, json } ) {
+    static async gradingImport( { cwd, path, onConflict, gradingDataDir, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
         if( grading === null || grading[ 'GradingImport' ] === undefined ) {
             return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
@@ -12166,7 +12191,7 @@ allowlist, migrate-config, etc.).
             return { 'result': FlowMcpCli.#error( { 'error': `Provider path not found: ${providerPath}`, 'fix': 'Pass an existing provider folder containing schema .mjs files.' } ) }
         }
 
-        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const gradingDataRoot = await FlowMcpCli.#gradingDataRoot( { cwd, gradingDataDir } )
         const { gate } = await FlowMcpCli.#buildGradingValidateGate()
 
         const run = await grading[ 'GradingImport' ].run( {
@@ -12202,7 +12227,7 @@ allowlist, migrate-config, etc.).
     }
 
 
-    static async gradingExport( { cwd, target, onConflict, json } ) {
+    static async gradingExport( { cwd, target, onConflict, gradingDataDir, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
         if( grading === null || grading[ 'GradingExport' ] === undefined ) {
             return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
@@ -12212,7 +12237,7 @@ allowlist, migrate-config, etc.).
             return { 'result': FlowMcpCli.#error( { 'error': 'Missing export target.', 'fix': 'Usage: flowmcp grading export <namespace|selection>' } ) }
         }
 
-        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const gradingDataRoot = await FlowMcpCli.#gradingDataRoot( { cwd, gradingDataDir } )
         const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
         if( detected.status !== true ) {
             return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }
@@ -12250,7 +12275,7 @@ allowlist, migrate-config, etc.).
     }
 
 
-    static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, json } ) {
+    static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, gradingDataDir, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
         if( grading === null ) {
             return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
@@ -12275,7 +12300,7 @@ allowlist, migrate-config, etc.).
             return { 'result': FlowMcpCli.#error( { 'error': `Invalid --on-conflict value: ${conflict}`, 'fix': `Use one of: ${validConflicts.join( ', ' )}.` } ) }
         }
 
-        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const gradingDataRoot = await FlowMcpCli.#gradingDataRoot( { cwd, gradingDataDir } )
 
         // F29 flow detection.
         const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
@@ -12560,7 +12585,7 @@ allowlist, migrate-config, etc.).
     }
 
 
-    static async gradingState( { cwd, target, json } ) {
+    static async gradingState( { cwd, target, gradingDataDir, json } ) {
         const grading = await FlowMcpCli.#loadGradingModule()
         if( grading === null ) {
             return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
@@ -12570,7 +12595,7 @@ allowlist, migrate-config, etc.).
             return { 'result': FlowMcpCli.#error( { 'error': 'Missing state target.', 'fix': 'Usage: flowmcp grading state <namespace|selection>' } ) }
         }
 
-        const gradingDataRoot = FlowMcpCli.#gradingDataRoot( { cwd } )
+        const gradingDataRoot = await FlowMcpCli.#gradingDataRoot( { cwd, gradingDataDir } )
         const detected = await FlowMcpCli.#detectGradingFlow( { gradingDataRoot, target } )
         if( detected.status !== true ) {
             return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -8211,6 +8211,17 @@ Selection Management (v4):
   dev selection show <name>                  Show selection details
   dev selection validate <path>              Validate a selection file
 
+Grading (v2):
+  grading import <provider-path>             Import a provider folder into the workbench island (Stage 0)
+  grading run <ns|selection> --emit-prompts  Stage 1: deterministic pretest + emit grading prompts (handoff)
+  grading run <ns|selection> --consume-scores <path>
+                                             Stage 3: consume harness scores, rebuild index, finalize
+    --phase <area>                           Restrict grading to a single area / skill
+    --on-conflict <abort|skip|overwrite>     Write-conflict policy (default: no-overwrite)
+  grading export <ns|selection>              Export graded state (index.json) back to the source
+  grading state <ns|selection>               Show current rollup status (read-only)
+  (also available as "${cmd} grading ..." — the "dev" prefix is optional)
+
 Shared Lists (v4):
   dev lists list                             List all shared lists
   dev lists show <name>                      Show shared list details

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -10088,6 +10088,22 @@ allowlist, migrate-config, etc.).
     }
 
 
+    // Lazy-import for the grading module's public surface (flowmcp-grading/src/index.mjs).
+    // PRODUCTION PIN at push-time (package.json) MUST be:
+    //   "flowmcp-grading": "github:FlowMCP/flowmcp-grading#85c2f621bf0135cddc8e473dc71ebea4bd2fe95f"
+    // Currently pinned to "file:../flowmcp-grading" because the P3 grading work is committed
+    // LOCALLY but NOT yet pushed to GitHub — a github:#<sha> pin would fail to install.
+    static async #loadGradingModule() {
+        if( FlowMcpCli.#gradingOverride ) { return FlowMcpCli.#gradingOverride }
+        try {
+            const grading = await import( 'flowmcp-grading' )
+            return grading
+        } catch {
+            return null
+        }
+    }
+
+
     static #enrichV4WithRuntimeMeta( { main, MetaGenerator } ) {
         const tools = main && main[ 'tools' ] ? main[ 'tools' ] : null
         if( !tools || typeof tools !== 'object' ) { return main }
@@ -11917,6 +11933,69 @@ allowlist, migrate-config, etc.).
 
     static __testInjectV4( { v4 } ) {
         FlowMcpCli.#v4Override = v4
+    }
+
+
+    static #gradingOverride = null
+
+
+    static __testInjectGrading( { grading } ) {
+        FlowMcpCli.#gradingOverride = grading
+    }
+
+
+    // Stub methods — the actual logic (stages, harness handoff) is PRD-011.
+    // Dispatch (PRD-010) routes here; until PRD-011 fills these in, they return
+    // a clear "not implemented yet" result (no silent skip, no throw).
+    static async gradingImport( { cwd, path, onConflict, json } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        const result = {
+            'status': false,
+            'error': 'grading import is not implemented yet (PRD-011).',
+            'fix': 'Pending PRD-011.',
+            'moduleLoaded': grading !== null
+        }
+
+        return { result }
+    }
+
+
+    static async gradingExport( { cwd, target, onConflict, json } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        const result = {
+            'status': false,
+            'error': 'grading export is not implemented yet (PRD-011).',
+            'fix': 'Pending PRD-011.',
+            'moduleLoaded': grading !== null
+        }
+
+        return { result }
+    }
+
+
+    static async gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, json } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        const result = {
+            'status': false,
+            'error': 'grading run is not implemented yet (PRD-011).',
+            'fix': 'Pending PRD-011.',
+            'moduleLoaded': grading !== null
+        }
+
+        return { result }
+    }
+
+
+    static async gradingState( { cwd, target, json } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        const result = {
+            'status': false,
+            'error': 'grading state is not implemented yet (PRD-011).',
+            'fix': 'Pending PRD-011.',
+            'moduleLoaded': grading !== null
+        }
+
+        return { result }
     }
 
 

--- a/tests/integration/fixtures/grading-provider/demoapi.mjs
+++ b/tests/integration/fixtures/grading-provider/demoapi.mjs
@@ -1,0 +1,34 @@
+const main = {
+    namespace: 'demoapi',
+    name: 'demoapi',
+    description: 'Demo provider schema used by grading integration tests.',
+    version: '4.0.0',
+    docs: [],
+    tags: [ 'test' ],
+    root: 'https://example.com',
+    requiredServerParams: [],
+    headers: {},
+    tools: {
+        getThing: {
+            method: 'GET',
+            path: '/thing',
+            description: 'Get a thing',
+            parameters: [],
+            tests: [ { _description: 't1' }, { _description: 't2' }, { _description: 't3' } ],
+            output: {
+                mimeType: 'application/json',
+                schema: {
+                    type: 'object',
+                    description: 'A thing',
+                    properties: {
+                        ok: { type: 'string', description: 'ok flag' }
+                    }
+                }
+            }
+        }
+    }
+}
+
+const handlers = {}
+
+export { main, handlers }

--- a/tests/integration/grading-data-root.test.mjs
+++ b/tests/integration/grading-data-root.test.mjs
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir, homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
+
+
+// The grading-data island root is configurable. Precedence (all explicit, no
+// silent default): --grading-data flag (cwd-relative) > FLOWMCP_GRADING_DATA env
+// (cwd-relative) > "gradingDataDir" in the GLOBAL ~/.flowmcp/config.json
+// (home-relative) > default ~/.flowmcp/grading.
+//
+// os.homedir() is mocked into <repo>/.test-home by the global-home setup, so the
+// "global home" here is the sandbox — the real ~/.flowmcp is never touched.
+
+const here = dirname( fileURLToPath( import.meta.url ) )
+const providerFixture = join( here, 'fixtures', 'grading-provider' )
+
+let cwd = null
+const savedEnv = process.env[ 'FLOWMCP_GRADING_DATA' ]
+
+const homeFlowmcp = () => join( homedir(), '.flowmcp' )
+
+
+beforeEach( async () => {
+    cwd = await mkdtemp( join( tmpdir(), 'grading-root-' ) )
+    delete process.env[ 'FLOWMCP_GRADING_DATA' ]
+    // Reset the shared sandbox-home state between cases (config + default island).
+    await rm( join( homeFlowmcp(), 'config.json' ), { force: true } )
+    await rm( join( homeFlowmcp(), 'grading' ), { recursive: true, force: true } )
+    await mkdir( homeFlowmcp(), { recursive: true } )
+} )
+
+afterEach( async () => {
+    if( savedEnv === undefined ) { delete process.env[ 'FLOWMCP_GRADING_DATA' ] }
+    else { process.env[ 'FLOWMCP_GRADING_DATA' ] = savedEnv }
+    await rm( join( homeFlowmcp(), 'config.json' ), { force: true } )
+    await rm( join( homeFlowmcp(), 'grading' ), { recursive: true, force: true } )
+    if( cwd !== null ) { await rm( cwd, { recursive: true, force: true } ) }
+} )
+
+const writeGlobalConfig = async ( { dataDir } ) => {
+    await mkdir( homeFlowmcp(), { recursive: true } )
+    await writeFile( join( homeFlowmcp(), 'config.json' ), JSON.stringify( { gradingDataDir: dataDir }, null, 4 ), 'utf-8' )
+}
+
+const importInto = ( opts ) => FlowMcpCli.gradingImport( { cwd, 'path': providerFixture, onConflict: null, gradingDataDir: null, json: true, ...opts } )
+
+
+describe( 'grading-data root is configurable (global ~/.flowmcp)', () => {
+    it( 'default lands in ~/.flowmcp/grading', async () => {
+        const { result } = await importInto( {} )
+        expect( result.status ).toBe( true )
+        expect( existsSync( join( homeFlowmcp(), 'grading', 'providers', result.namespace ) ) ).toBe( true )
+    } )
+
+    it( 'config.json "gradingDataDir" (home-relative) overrides the default', async () => {
+        await writeGlobalConfig( { dataDir: 'configured-island' } )
+        const { result } = await importInto( {} )
+        expect( result.status ).toBe( true )
+        expect( existsSync( join( homeFlowmcp(), 'configured-island', 'providers', result.namespace ) ) ).toBe( true )
+        expect( existsSync( join( homeFlowmcp(), 'grading' ) ) ).toBe( false )
+    } )
+
+    it( 'FLOWMCP_GRADING_DATA env (cwd-relative) wins over config.json', async () => {
+        await writeGlobalConfig( { dataDir: 'configured-island' } )
+        process.env[ 'FLOWMCP_GRADING_DATA' ] = 'env-island'
+        const { result } = await importInto( {} )
+        expect( result.status ).toBe( true )
+        expect( existsSync( join( cwd, 'env-island', 'providers', result.namespace ) ) ).toBe( true )
+    } )
+
+    it( '--grading-data flag (cwd-relative) wins over env and config.json', async () => {
+        await writeGlobalConfig( { dataDir: 'configured-island' } )
+        process.env[ 'FLOWMCP_GRADING_DATA' ] = 'env-island'
+        const { result } = await importInto( { gradingDataDir: 'flag-island' } )
+        expect( result.status ).toBe( true )
+        expect( existsSync( join( cwd, 'flag-island', 'providers', result.namespace ) ) ).toBe( true )
+        expect( existsSync( join( cwd, 'env-island' ) ) ).toBe( false )
+    } )
+} )

--- a/tests/integration/grading-selection-f16.test.mjs
+++ b/tests/integration/grading-selection-f16.test.mjs
@@ -35,7 +35,7 @@ beforeEach( async () => {
     root = await mkdtemp( join( tmpdir(), 'sel-f16-' ) )
     cwd = root
     // Island with a selection that references an un-imported member demo.thing.
-    const selDef = join( root, 'grading-data', 'selections', 'cryptotest', 'selection' )
+    const selDef = join( root, '.flowmcp', 'grading','selections', 'cryptotest', 'selection' )
     await mkdir( selDef, { recursive: true } )
     await writeFile(
         join( selDef, 'cryptotest--2026-01-01T00-00-00Z--abcd1234.json' ),
@@ -56,7 +56,7 @@ afterEach( async () => {
 describe( 'grading run <selection> — F16 case (a) member auto-chain', () => {
     it( 'auto-builds the selection index and auto-chains the missing member when --member-source is given', async () => {
         const { result } = await FlowMcpCli.gradingRun( {
-            cwd, target: 'cryptotest', phase: null, emitPrompts: true,
+            cwd, gradingDataDir: '.flowmcp/grading', target: 'cryptotest', phase: null, emitPrompts: true,
             consumeScores: null, onConflict: null, memberSource: memberSourceRoot, json: true
         } )
 
@@ -67,7 +67,7 @@ describe( 'grading run <selection> — F16 case (a) member auto-chain', () => {
         const done = chain.some( ( s ) => s.step === 'member-auto-chain' && s.status === 'done' )
         expect( done ).toBe( true )
         // The missing member's namespace was imported into the island.
-        expect( existsSync( join( root, 'grading-data', 'providers', 'demo', 'thing' ) ) ).toBe( true )
+        expect( existsSync( join( root, '.flowmcp', 'grading','providers', 'demo', 'thing' ) ) ).toBe( true )
         // Pre-Condition still blocks (member imported but not stable) — no silent pass.
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'PRE-004' )
@@ -75,7 +75,7 @@ describe( 'grading run <selection> — F16 case (a) member auto-chain', () => {
 
     it( 'reports the missing member (no silent import) when --member-source is absent', async () => {
         const { result } = await FlowMcpCli.gradingRun( {
-            cwd, target: 'cryptotest', phase: null, emitPrompts: true,
+            cwd, gradingDataDir: '.flowmcp/grading', target: 'cryptotest', phase: null, emitPrompts: true,
             consumeScores: null, onConflict: null, memberSource: null, json: true
         } )
 
@@ -84,7 +84,7 @@ describe( 'grading run <selection> — F16 case (a) member auto-chain', () => {
         expect( report ).toBeDefined()
         expect( report.missingMembers ).toContain( 'demo.thing' )
         // No source -> the member was NOT imported.
-        expect( existsSync( join( root, 'grading-data', 'providers', 'demo' ) ) ).toBe( false )
+        expect( existsSync( join( root, '.flowmcp', 'grading','providers', 'demo' ) ) ).toBe( false )
         expect( result.status ).toBe( false )
     } )
 } )

--- a/tests/integration/grading-selection-f16.test.mjs
+++ b/tests/integration/grading-selection-f16.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
+
+
+// Selection-flow F16 dependency resolver (case a: missing member -> auto-chain
+// import from --member-source; report-only without it). Uses the real grading
+// module; import is structural (no HTTP) and the Pre-Condition gate blocks before
+// Stage 1, so no live API call is made.
+
+let root = null
+let cwd = null
+let memberSourceRoot = null
+
+
+const schemaSource = ( { namespace, name } ) => `export const main = {
+    namespace: ${JSON.stringify( namespace )},
+    name: ${JSON.stringify( name )},
+    description: 'Demo schema for the F16 member auto-chain test.',
+    version: '4.0.0',
+    root: 'https://api.example.com',
+    tools: {
+        foo: { method: 'GET', path: '/foo', description: 'fetch foo', parameters: [] }
+    }
+}
+export async function handler() { return { status: true } }
+`
+
+
+beforeEach( async () => {
+    root = await mkdtemp( join( tmpdir(), 'sel-f16-' ) )
+    cwd = root
+    // Island with a selection that references an un-imported member demo.thing.
+    const selDef = join( root, 'grading-data', 'selections', 'cryptotest', 'selection' )
+    await mkdir( selDef, { recursive: true } )
+    await writeFile(
+        join( selDef, 'cryptotest--2026-01-01T00-00-00Z--abcd1234.json' ),
+        JSON.stringify( { selectionId: 'cryptotest', members: [ { schemaId: 'demo.thing' } ], skills: [], personaIds: [ 'decision-maker--crypto-trader' ] }, null, 4 ),
+        'utf-8'
+    )
+    // A member source root containing the demo namespace (thing.mjs).
+    memberSourceRoot = join( root, 'member-source' )
+    await mkdir( join( memberSourceRoot, 'demo' ), { recursive: true } )
+    await writeFile( join( memberSourceRoot, 'demo', 'thing.mjs' ), schemaSource( { namespace: 'demo', name: 'Demo Thing' } ), 'utf-8' )
+} )
+
+afterEach( async () => {
+    if( root !== null ) { await rm( root, { recursive: true, force: true } ) }
+} )
+
+
+describe( 'grading run <selection> — F16 case (a) member auto-chain', () => {
+    it( 'auto-builds the selection index and auto-chains the missing member when --member-source is given', async () => {
+        const { result } = await FlowMcpCli.gradingRun( {
+            cwd, target: 'cryptotest', phase: null, emitPrompts: true,
+            consumeScores: null, onConflict: null, memberSource: memberSourceRoot, json: true
+        } )
+
+        const chain = result.dependencyChain || []
+        const steps = chain.map( ( s ) => s.step )
+        expect( steps ).toContain( 'auto-build-selection-index' )
+        expect( steps ).toContain( 'member-auto-chain' )
+        const done = chain.some( ( s ) => s.step === 'member-auto-chain' && s.status === 'done' )
+        expect( done ).toBe( true )
+        // The missing member's namespace was imported into the island.
+        expect( existsSync( join( root, 'grading-data', 'providers', 'demo', 'thing' ) ) ).toBe( true )
+        // Pre-Condition still blocks (member imported but not stable) — no silent pass.
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'PRE-004' )
+    } )
+
+    it( 'reports the missing member (no silent import) when --member-source is absent', async () => {
+        const { result } = await FlowMcpCli.gradingRun( {
+            cwd, target: 'cryptotest', phase: null, emitPrompts: true,
+            consumeScores: null, onConflict: null, memberSource: null, json: true
+        } )
+
+        const chain = result.dependencyChain || []
+        const report = chain.find( ( s ) => s.step === 'member-report' )
+        expect( report ).toBeDefined()
+        expect( report.missingMembers ).toContain( 'demo.thing' )
+        // No source -> the member was NOT imported.
+        expect( existsSync( join( root, 'grading-data', 'providers', 'demo' ) ) ).toBe( false )
+        expect( result.status ).toBe( false )
+    } )
+} )

--- a/tests/unit/cli-grading-dispatch.test.mjs
+++ b/tests/unit/cli-grading-dispatch.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from '@jest/globals'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
+
+
+const here = dirname( fileURLToPath( import.meta.url ) )
+const cliBin = join( here, '..', '..', 'src', 'index.mjs' )
+
+
+const runCli = ( { args } ) => {
+    return new Promise( ( resolve ) => {
+        execFile( process.execPath, [ cliBin, ...args ], { 'encoding': 'utf8' }, ( error, stdout, stderr ) => {
+            resolve( { stdout, stderr, error } )
+        } )
+    } )
+}
+
+
+describe( 'grading dispatch — allowlist + dev-prefix-strip', () => {
+    it( 'returns an allowlist error when no sub-command is given', async () => {
+        const { stdout } = await runCli( { 'args': [ 'grading' ] } )
+        const parsed = JSON.parse( stdout )
+
+        expect( parsed[ 'status' ] ).toBe( false )
+        expect( parsed[ 'error' ] ).toBe( 'Missing or unknown grading sub-command.' )
+        expect( parsed[ 'fix' ] ).toContain( 'import' )
+        expect( parsed[ 'fix' ] ).toContain( 'export' )
+        expect( parsed[ 'fix' ] ).toContain( 'run' )
+        expect( parsed[ 'fix' ] ).toContain( 'state' )
+    } )
+
+    it( 'returns an allowlist error for an unknown sub-command', async () => {
+        const { stdout } = await runCli( { 'args': [ 'grading', 'bogus' ] } )
+        const parsed = JSON.parse( stdout )
+
+        expect( parsed[ 'status' ] ).toBe( false )
+        expect( parsed[ 'error' ] ).toBe( 'Missing or unknown grading sub-command.' )
+    } )
+
+    it( 'reuses the same block via the dev-prefix-strip (flowmcp dev grading)', async () => {
+        const { stdout } = await runCli( { 'args': [ 'dev', 'grading' ] } )
+        const parsed = JSON.parse( stdout )
+
+        expect( parsed[ 'status' ] ).toBe( false )
+        expect( parsed[ 'error' ] ).toBe( 'Missing or unknown grading sub-command.' )
+        expect( parsed[ 'fix' ] ).toContain( 'import' )
+    } )
+
+    it( 'does not fall through to the unknown-command fallback for grading', async () => {
+        const { stdout } = await runCli( { 'args': [ 'grading' ] } )
+        const parsed = JSON.parse( stdout )
+
+        expect( parsed[ 'error' ] ).not.toContain( 'Unknown command' )
+    } )
+
+    it( 'routes a valid sub-command to its method (run)', async () => {
+        const { stdout } = await runCli( { 'args': [ 'grading', 'run', 'demo/ns', '--phase', 'P1' ] } )
+        const parsed = JSON.parse( stdout )
+
+        expect( parsed[ 'status' ] ).toBe( false )
+        expect( parsed[ 'error' ] ).toContain( 'grading run is not implemented yet' )
+    } )
+} )
+
+
+describe( 'grading methods — module injection + argument pass-through', () => {
+    afterEach( () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': null } )
+    } )
+
+    it( 'loads the injected grading module for gradingImport', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingImport': {} } } )
+        const { result } = await FlowMcpCli.gradingImport( { 'cwd': '/tmp', 'path': 'x', 'onConflict': null, 'json': false } )
+
+        expect( result[ 'moduleLoaded' ] ).toBe( true )
+        expect( result[ 'status' ] ).toBe( false )
+    } )
+
+    it( 'loads the injected grading module for gradingExport', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingExport': {} } } )
+        const { result } = await FlowMcpCli.gradingExport( { 'cwd': '/tmp', 'target': 'ns', 'onConflict': null, 'json': false } )
+
+        expect( result[ 'moduleLoaded' ] ).toBe( true )
+    } )
+
+    it( 'loads the injected grading module for gradingRun', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'gradeSelection': () => {} } } )
+        const { result } = await FlowMcpCli.gradingRun( { 'cwd': '/tmp', 'target': 'ns', 'phase': 'P1', 'emitPrompts': false, 'consumeScores': null, 'onConflict': null, 'json': false } )
+
+        expect( result[ 'moduleLoaded' ] ).toBe( true )
+    } )
+
+    it( 'loads the injected grading module for gradingState', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'ModuleApi': {} } } )
+        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': 'ns', 'json': false } )
+
+        expect( result[ 'moduleLoaded' ] ).toBe( true )
+    } )
+
+    it( 'resolves the real flowmcp-grading module via lazy import (no injection)', async () => {
+        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': 'ns', 'json': false } )
+
+        expect( result[ 'moduleLoaded' ] ).toBe( true )
+    } )
+} )

--- a/tests/unit/cli-grading-dispatch.test.mjs
+++ b/tests/unit/cli-grading-dispatch.test.mjs
@@ -57,52 +57,69 @@ describe( 'grading dispatch — allowlist + dev-prefix-strip', () => {
     } )
 
     it( 'routes a valid sub-command to its method (run)', async () => {
+        // PRD-011: the method now requires a mode flag. Without --emit-prompts /
+        // --consume-scores it returns the no-default-mode error (not a stub).
         const { stdout } = await runCli( { 'args': [ 'grading', 'run', 'demo/ns', '--phase', 'P1' ] } )
         const parsed = JSON.parse( stdout )
 
         expect( parsed[ 'status' ] ).toBe( false )
-        expect( parsed[ 'error' ] ).toContain( 'grading run is not implemented yet' )
+        expect( parsed[ 'error' ] ).toContain( 'Mode required' )
     } )
 } )
 
 
-describe( 'grading methods — module injection + argument pass-through', () => {
+describe( 'grading methods — module guard + input validation', () => {
     afterEach( () => {
         FlowMcpCli.__testInjectGrading( { 'grading': null } )
     } )
 
-    it( 'loads the injected grading module for gradingImport', async () => {
-        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingImport': {} } } )
+    it( 'gradingImport aborts when the grading module is unavailable', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'NotGradingImport': {} } } )
         const { result } = await FlowMcpCli.gradingImport( { 'cwd': '/tmp', 'path': 'x', 'onConflict': null, 'json': false } )
 
-        expect( result[ 'moduleLoaded' ] ).toBe( true )
         expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toBe( 'grading module unavailable' )
     } )
 
-    it( 'loads the injected grading module for gradingExport', async () => {
-        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingExport': {} } } )
-        const { result } = await FlowMcpCli.gradingExport( { 'cwd': '/tmp', 'target': 'ns', 'onConflict': null, 'json': false } )
+    it( 'gradingImport reports a missing provider path', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingImport': { 'run': async () => ( {} ) } } } )
+        const { result } = await FlowMcpCli.gradingImport( { 'cwd': '/tmp', 'path': '', 'onConflict': null, 'json': false } )
 
-        expect( result[ 'moduleLoaded' ] ).toBe( true )
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'Missing provider path' )
     } )
 
-    it( 'loads the injected grading module for gradingRun', async () => {
-        FlowMcpCli.__testInjectGrading( { 'grading': { 'gradeSelection': () => {} } } )
-        const { result } = await FlowMcpCli.gradingRun( { 'cwd': '/tmp', 'target': 'ns', 'phase': 'P1', 'emitPrompts': false, 'consumeScores': null, 'onConflict': null, 'json': false } )
+    it( 'gradingExport reports a missing target', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'GradingExport': { 'run': async () => ( {} ) } } } )
+        const { result } = await FlowMcpCli.gradingExport( { 'cwd': '/tmp', 'target': '', 'onConflict': null, 'json': false } )
 
-        expect( result[ 'moduleLoaded' ] ).toBe( true )
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'Missing export target' )
     } )
 
-    it( 'loads the injected grading module for gradingState', async () => {
+    it( 'gradingRun requires a mode flag (no silent default)', async () => {
+        FlowMcpCli.__testInjectGrading( { 'grading': { 'RebuildIndex': {} } } )
+        const { result } = await FlowMcpCli.gradingRun( { 'cwd': '/tmp', 'target': 'ns', 'phase': null, 'emitPrompts': false, 'consumeScores': null, 'onConflict': null, 'json': false } )
+
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'Mode required' )
+    } )
+
+    it( 'gradingState reports a missing target', async () => {
         FlowMcpCli.__testInjectGrading( { 'grading': { 'ModuleApi': {} } } )
-        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': 'ns', 'json': false } )
+        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': '', 'json': false } )
 
-        expect( result[ 'moduleLoaded' ] ).toBe( true )
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'Missing state target' )
     } )
 
     it( 'resolves the real flowmcp-grading module via lazy import (no injection)', async () => {
-        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': 'ns', 'json': false } )
+        // No injection -> the lazy import resolves the real module. With a
+        // nonexistent target the flow-detection error proves the module loaded
+        // and the method ran past the module guard.
+        const { result } = await FlowMcpCli.gradingState( { 'cwd': '/tmp', 'target': 'does-not-exist', 'json': false } )
 
-        expect( result[ 'moduleLoaded' ] ).toBe( true )
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'found in neither' )
     } )
 } )

--- a/tests/unit/grading-methods.test.mjs
+++ b/tests/unit/grading-methods.test.mjs
@@ -53,31 +53,31 @@ describe( 'gradingImport — Stage 0 intake (real module)', () => {
 
     it( 'imports a fixture provider into the island + builds index.json', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.namespace ).toBe( 'demoapi' )
         expect( result.indexPath ).toContain( 'index.json' )
         expect( existsSync( result.indexPath ) ).toBe( true )
 
-        const islandSchema = join( cwd, 'grading-data', 'providers', 'demoapi', 'demoapi', 'schema' )
+        const islandSchema = join( cwd, '.flowmcp', 'grading','providers', 'demoapi', 'demoapi', 'schema' )
         expect( existsSync( islandSchema ) ).toBe( true )
         const snapshots = await readdir( islandSchema )
         expect( snapshots.some( ( n ) => n.endsWith( '.mjs' ) ) ).toBe( true )
     } )
 
-    it( 'never writes outside cwd/grading-data (no ~/.flowmcp touch)', async () => {
+    it( 'never writes outside cwd/.flowmcp/grading (no real ~/.flowmcp touch)', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
-        expect( result.indexPath.startsWith( join( cwd, 'grading-data' ) ) ).toBe( true )
+        expect( result.indexPath.startsWith( join( cwd, '.flowmcp', 'grading' ) ) ).toBe( true )
     } )
 
     it( 'skips an unchanged schema on a second import (same hash, no overwrite)', async () => {
         const cwd = await freshCwd()
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
-        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.skipped.length ).toBeGreaterThan( 0 )
@@ -87,7 +87,7 @@ describe( 'gradingImport — Stage 0 intake (real module)', () => {
     it( 'aborts when the grading module is unavailable', async () => {
         FlowMcpCli.__testInjectGrading( { grading: {} } )
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toBe( 'grading module unavailable' )
@@ -95,7 +95,7 @@ describe( 'gradingImport — Stage 0 intake (real module)', () => {
 
     it( 'reports a non-existent provider path', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingImport( { cwd, path: 'does/not/exist', onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: 'does/not/exist', onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'not found' )
@@ -108,7 +108,7 @@ describe( 'gradingRun — flow detection (F29)', () => {
 
     it( 'errors when the target is in neither providers nor selections', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'ghost', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'ghost', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'found in neither' )
@@ -117,10 +117,10 @@ describe( 'gradingRun — flow detection (F29)', () => {
 
     it( 'errors ambiguously when the target is in both trees', async () => {
         const cwd = await freshCwd()
-        await mkdir( join( cwd, 'grading-data', 'providers', 'dup' ), { recursive: true } )
-        await mkdir( join( cwd, 'grading-data', 'selections', 'dup' ), { recursive: true } )
+        await mkdir( join( cwd, '.flowmcp', 'grading','providers', 'dup' ), { recursive: true } )
+        await mkdir( join( cwd, '.flowmcp', 'grading','selections', 'dup' ), { recursive: true } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'dup', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'dup', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'Ambiguous' )
@@ -130,9 +130,9 @@ describe( 'gradingRun — flow detection (F29)', () => {
     it( 'detects the provider tier (autonomous, max B) on emit-prompts', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.flow ).toBe( 'provider' )
@@ -147,7 +147,7 @@ describe( 'gradingRun — mode + conflict guards (no silent defaults)', () => {
 
     it( 'requires exactly one mode flag', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: false, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'Mode required' )
@@ -155,7 +155,7 @@ describe( 'gradingRun — mode + conflict guards (no silent defaults)', () => {
 
     it( 'rejects both modes at once', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: 'x.json', onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: 'x.json', onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'mutually exclusive' )
@@ -163,7 +163,7 @@ describe( 'gradingRun — mode + conflict guards (no silent defaults)', () => {
 
     it( 'rejects an invalid --on-conflict value', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'nuke', json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'nuke', json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'Invalid --on-conflict' )
@@ -177,10 +177,10 @@ describe( 'gradingRun — F16 dependency resolver', () => {
     it( 'hard-aborts when index.json is missing and no source is available', async () => {
         const cwd = await freshCwd()
         // A provider folder exists (F29 passes) but it has no index.json.
-        await mkdir( join( cwd, 'grading-data', 'providers', 'bare' ), { recursive: true } )
+        await mkdir( join( cwd, '.flowmcp', 'grading','providers', 'bare' ), { recursive: true } )
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'bare', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'bare', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'No index.json' )
@@ -190,9 +190,9 @@ describe( 'gradingRun — F16 dependency resolver', () => {
     it( 'reports (does not block) when rollup quality is below stable', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         const reportStep = result.dependencyChain.find( ( s ) => s.step === 'quality-report' )
@@ -208,9 +208,9 @@ describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
     it( 'emits prompts.json + state.json with a Goal-Block', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.stage ).toBe( 1 )
@@ -229,9 +229,9 @@ describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
     it( 'F26: persisted pretest handoff carries no request field and no key value', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
         const raw = await readFile( result.promptsPath, 'utf-8' )
 
         expect( raw ).not.toContain( '"request"' )
@@ -245,10 +245,10 @@ describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
     it( 'second emit with --on-conflict=abort returns a NO-OVERWRITE error', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
-        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'abort', json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'abort', json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'NO-OVERWRITE' )
@@ -257,10 +257,10 @@ describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
     it( 'second emit with --on-conflict=skip keeps the existing handoff', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
-        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'skip', json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'skip', json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.skipped ).toBe( true )
@@ -270,9 +270,9 @@ describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
         const cwd = await freshCwd()
         const injected = gradingWithStubbedPretest( { ok: true } )
         FlowMcpCli.__testInjectGrading( { grading: injected } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         expect( injected.__stub.lastCall ).not.toBeNull()
         expect( typeof injected.__stub.lastCall.serverParams ).toBe( 'object' )
@@ -288,20 +288,20 @@ describe( 'gradingRun — Stage 3 consume-scores', () => {
     it( 'consumes a scores fixture, rebuilds the 5-status index, finalizes state', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
-        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
 
         const scoresPath = join( cwd, 'scores.json' )
         await writeFile( scoresPath, JSON.stringify( { scoringProtocol: 'v1', scores: [ { dimension: 'whenToUse', score: 4.0 } ] } ), 'utf-8' )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: scoresPath, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: false, consumeScores: scoresPath, onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.stage ).toBe( 3 )
         expect( result.indexPath ).toContain( 'index.json' )
         expect( typeof result.rollupStatus ).toBe( 'string' )
 
-        const state = JSON.parse( await readFile( result.statePath || join( cwd, 'grading-data', 'providers', 'demoapi', 'state.json' ), 'utf-8' ) )
+        const state = JSON.parse( await readFile( result.statePath || join( cwd, '.flowmcp', 'grading','providers', 'demoapi', 'state.json' ), 'utf-8' ) )
         expect( state.status ).toBe( 'graded' )
         expect( state.phases.indexRebuilt ).not.toBeNull()
     } )
@@ -309,9 +309,9 @@ describe( 'gradingRun — Stage 3 consume-scores', () => {
     it( 'reports a missing scores file', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: 'nope.json', onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingRun( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', phase: null, emitPrompts: false, consumeScores: 'nope.json', onConflict: null, json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'Scores file not found' )
@@ -325,9 +325,9 @@ describe( 'gradingState — read-only rollup', () => {
     it( 'returns the rollup state for an imported namespace (read-only)', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
 
-        const { result } = await FlowMcpCli.gradingState( { cwd, target: 'demoapi', json: false } )
+        const { result } = await FlowMcpCli.gradingState( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.flow ).toBe( 'provider' )
@@ -337,7 +337,7 @@ describe( 'gradingState — read-only rollup', () => {
 
     it( 'errors for an unknown target', async () => {
         const cwd = await freshCwd()
-        const { result } = await FlowMcpCli.gradingState( { cwd, target: 'unknown', json: false } )
+        const { result } = await FlowMcpCli.gradingState( { cwd, gradingDataDir: '.flowmcp/grading', target:'unknown', json: false } )
 
         expect( result.status ).toBe( false )
         expect( result.error ).toContain( 'found in neither' )
@@ -351,10 +351,10 @@ describe( 'gradingExport — OUT round-trip (never overwrites source)', () => {
     it( 'exports index.json into a fresh folder, source untouched', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        const imp = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const imp = await FlowMcpCli.gradingImport( { cwd, gradingDataDir: '.flowmcp/grading', path: providerFixture, onConflict: null, json: false } )
         const sourceIndex = imp.result.indexPath
 
-        const { result } = await FlowMcpCli.gradingExport( { cwd, target: 'demoapi', onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingExport( { cwd, gradingDataDir: '.flowmcp/grading', target:'demoapi', onConflict: null, json: false } )
 
         expect( result.status ).toBe( true )
         expect( result.flow ).toBe( 'namespace' )

--- a/tests/unit/grading-methods.test.mjs
+++ b/tests/unit/grading-methods.test.mjs
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { mkdir, mkdtemp, cp, readFile, writeFile, readdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+import { FlowMcpCli } from '../../src/task/FlowMcpCli.mjs'
+import * as realGrading from 'flowmcp-grading'
+
+
+const here = dirname( fileURLToPath( import.meta.url ) )
+const providerFixture = join( here, '..', 'integration', 'fixtures', 'grading-provider' )
+
+
+// Wrap the real grading module but stub DataPretest.run so the emit-prompts
+// stage never makes a live API call (live runs are P5). Everything else
+// (GradingImport, RebuildIndex, PromptBuilder, GradingExport) is the real code.
+function gradingWithStubbedPretest( { ok = true } ) {
+    let lastCall = null
+    const stub = {
+        run: async ( params ) => {
+            lastCall = params
+            return {
+                ok,
+                passedDownloadable: ok ? 3 : 0,
+                required: 3,
+                toolsBelowThreshold: ok ? [] : [ 'getThing (0/3)' ],
+                perTool: {},
+                schemaDir: null,
+                summaryPath: join( params.gradingDataDir, 'providers', params.namespace, params.toolName, 'summary.json' ),
+                results: [],
+                stopReason: ok ? null : 'no-downloadable-tools',
+                errors: []
+            }
+        },
+        getVersion: () => ( { version: 'stub' } ),
+        get lastCall() { return lastCall }
+    }
+
+    return { ...realGrading, DataPretest: stub, __stub: stub }
+}
+
+
+async function freshCwd() {
+    const base = await mkdtemp( join( tmpdir(), 'grading-cwd-' ) )
+    return base
+}
+
+
+describe( 'gradingImport — Stage 0 intake (real module)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'imports a fixture provider into the island + builds index.json', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.namespace ).toBe( 'demoapi' )
+        expect( result.indexPath ).toContain( 'index.json' )
+        expect( existsSync( result.indexPath ) ).toBe( true )
+
+        const islandSchema = join( cwd, 'grading-data', 'providers', 'demoapi', 'demoapi', 'schema' )
+        expect( existsSync( islandSchema ) ).toBe( true )
+        const snapshots = await readdir( islandSchema )
+        expect( snapshots.some( ( n ) => n.endsWith( '.mjs' ) ) ).toBe( true )
+    } )
+
+    it( 'never writes outside cwd/grading-data (no ~/.flowmcp touch)', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.indexPath.startsWith( join( cwd, 'grading-data' ) ) ).toBe( true )
+    } )
+
+    it( 'skips an unchanged schema on a second import (same hash, no overwrite)', async () => {
+        const cwd = await freshCwd()
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.skipped.length ).toBeGreaterThan( 0 )
+        expect( result.imported.length ).toBe( 0 )
+    } )
+
+    it( 'aborts when the grading module is unavailable', async () => {
+        FlowMcpCli.__testInjectGrading( { grading: {} } )
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toBe( 'grading module unavailable' )
+    } )
+
+    it( 'reports a non-existent provider path', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingImport( { cwd, path: 'does/not/exist', onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'not found' )
+    } )
+} )
+
+
+describe( 'gradingRun — flow detection (F29)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'errors when the target is in neither providers nor selections', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'ghost', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'found in neither' )
+        expect( result.fix ).toContain( 'grading import' )
+    } )
+
+    it( 'errors ambiguously when the target is in both trees', async () => {
+        const cwd = await freshCwd()
+        await mkdir( join( cwd, 'grading-data', 'providers', 'dup' ), { recursive: true } )
+        await mkdir( join( cwd, 'grading-data', 'selections', 'dup' ), { recursive: true } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'dup', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'Ambiguous' )
+        expect( result.fix ).toContain( 'explicit path' )
+    } )
+
+    it( 'detects the provider tier (autonomous, max B) on emit-prompts', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.flow ).toBe( 'provider' )
+        expect( result.tier ).toBe( 'autonomous' )
+        expect( result.maxGrade ).toBe( 'B' )
+    } )
+} )
+
+
+describe( 'gradingRun — mode + conflict guards (no silent defaults)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'requires exactly one mode flag', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'Mode required' )
+    } )
+
+    it( 'rejects both modes at once', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: 'x.json', onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'mutually exclusive' )
+    } )
+
+    it( 'rejects an invalid --on-conflict value', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'nuke', json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'Invalid --on-conflict' )
+    } )
+} )
+
+
+describe( 'gradingRun — F16 dependency resolver', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'hard-aborts when index.json is missing and no source is available', async () => {
+        const cwd = await freshCwd()
+        // A provider folder exists (F29 passes) but it has no index.json.
+        await mkdir( join( cwd, 'grading-data', 'providers', 'bare' ), { recursive: true } )
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'bare', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'No index.json' )
+        expect( Array.isArray( result.dependencyChain ) ).toBe( true )
+    } )
+
+    it( 'reports (does not block) when rollup quality is below stable', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        const reportStep = result.dependencyChain.find( ( s ) => s.step === 'quality-report' )
+        expect( reportStep ).toBeDefined()
+        expect( reportStep.note ).toContain( 'no downgrade' )
+    } )
+} )
+
+
+describe( 'gradingRun — Stage 1 emit-prompts (handoff + baton)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'emits prompts.json + state.json with a Goal-Block', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.stage ).toBe( 1 )
+        expect( existsSync( result.promptsPath ) ).toBe( true )
+        expect( existsSync( result.statePath ) ).toBe( true )
+
+        const prompts = JSON.parse( await readFile( result.promptsPath, 'utf-8' ) )
+        expect( prompts.goal.goalBlock ).toContain( 'Goal-Block' )
+        expect( prompts.goal.condition ).toContain( 'stop after' )
+
+        const state = JSON.parse( await readFile( result.statePath, 'utf-8' ) )
+        expect( state.status ).toBe( 'prompts-emitted' )
+        expect( state.phases.promptsEmitted ).not.toBeNull()
+    } )
+
+    it( 'F26: persisted pretest handoff carries no request field and no key value', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+        const raw = await readFile( result.promptsPath, 'utf-8' )
+
+        expect( raw ).not.toContain( '"request"' )
+        expect( raw ).not.toContain( '_allParams' )
+        const prompts = JSON.parse( raw )
+        prompts.pretests.forEach( ( p ) => {
+            expect( p.request ).toBeUndefined()
+        } )
+    } )
+
+    it( 'second emit with --on-conflict=abort returns a NO-OVERWRITE error', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'abort', json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'NO-OVERWRITE' )
+    } )
+
+    it( 'second emit with --on-conflict=skip keeps the existing handoff', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: 'skip', json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.skipped ).toBe( true )
+    } )
+
+    it( 'passes flat serverParams to DataPretest.run (CLI is the only env consumer)', async () => {
+        const cwd = await freshCwd()
+        const injected = gradingWithStubbedPretest( { ok: true } )
+        FlowMcpCli.__testInjectGrading( { grading: injected } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        expect( injected.__stub.lastCall ).not.toBeNull()
+        expect( typeof injected.__stub.lastCall.serverParams ).toBe( 'object' )
+        expect( Array.isArray( injected.__stub.lastCall.serverParams ) ).toBe( false )
+        expect( injected.__stub.lastCall.main ).toBeDefined()
+    } )
+} )
+
+
+describe( 'gradingRun — Stage 3 consume-scores', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'consumes a scores fixture, rebuilds the 5-status index, finalizes state', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: true, consumeScores: null, onConflict: null, json: false } )
+
+        const scoresPath = join( cwd, 'scores.json' )
+        await writeFile( scoresPath, JSON.stringify( { scoringProtocol: 'v1', scores: [ { dimension: 'whenToUse', score: 4.0 } ] } ), 'utf-8' )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: scoresPath, onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.stage ).toBe( 3 )
+        expect( result.indexPath ).toContain( 'index.json' )
+        expect( typeof result.rollupStatus ).toBe( 'string' )
+
+        const state = JSON.parse( await readFile( result.statePath || join( cwd, 'grading-data', 'providers', 'demoapi', 'state.json' ), 'utf-8' ) )
+        expect( state.status ).toBe( 'graded' )
+        expect( state.phases.indexRebuilt ).not.toBeNull()
+    } )
+
+    it( 'reports a missing scores file', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingRun( { cwd, target: 'demoapi', phase: null, emitPrompts: false, consumeScores: 'nope.json', onConflict: null, json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'Scores file not found' )
+    } )
+} )
+
+
+describe( 'gradingState — read-only rollup', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'returns the rollup state for an imported namespace (read-only)', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+
+        const { result } = await FlowMcpCli.gradingState( { cwd, target: 'demoapi', json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.flow ).toBe( 'provider' )
+        expect( result.indexPresent ).toBe( true )
+        expect( typeof result.rollupStatus ).toBe( 'string' )
+    } )
+
+    it( 'errors for an unknown target', async () => {
+        const cwd = await freshCwd()
+        const { result } = await FlowMcpCli.gradingState( { cwd, target: 'unknown', json: false } )
+
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'found in neither' )
+    } )
+} )
+
+
+describe( 'gradingExport — OUT round-trip (never overwrites source)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'exports index.json into a fresh folder, source untouched', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        const imp = await FlowMcpCli.gradingImport( { cwd, path: providerFixture, onConflict: null, json: false } )
+        const sourceIndex = imp.result.indexPath
+
+        const { result } = await FlowMcpCli.gradingExport( { cwd, target: 'demoapi', onConflict: null, json: false } )
+
+        expect( result.status ).toBe( true )
+        expect( result.flow ).toBe( 'namespace' )
+        expect( existsSync( result.indexExportPath ) ).toBe( true )
+        // The fresh export folder must be distinct from the source index folder.
+        expect( dirname( result.indexExportPath ) ).not.toBe( dirname( sourceIndex ) )
+        expect( existsSync( sourceIndex ) ).toBe( true )
+    } )
+} )


### PR DESCRIPTION
The `flowmcp grading` CLI area (Memo 085 P4) + the configurable island location + the github dependency pin.

## Scope
- `grading import/export/run/state` dispatch + four methods; Stages 0/1/2/3 via state.json baton; F29 flow auto-detection; F16 dependency resolver (provider auto-chain, selection index bootstrap, member auto-chain via --member-source, report/abort branches).
- Phase-0/1 wiring (#resolveEnv→#buildServerParams→#loadSchema→DataPretest.run); write-safety (#writeGuarded/#writeAtomic); F26 (no request/key persisted).
- Configurable island location: --grading-data flag > FLOWMCP_GRADING_DATA env > "gradingDataDir" in ~/.flowmcp/config.json > default ~/.flowmcp/grading (all explicit, no silent default).
- Dependency pinned to github:FlowMCP/flowmcp-grading#e911958 (was file:) for standalone install.
- Help + README documented.

## Verification
- 770/782 tests pass serially; the 12 failures are pre-existing LIVE-NETWORK callTool tests (httpbin.org timeouts) degraded by local env — 0 logic/resolution failures (CI on a clean runner is the gate).
- End-to-end proven against the github-backed grading module (import + run --emit-prompts + state).
- Memo-068 test isolation intact (mocked home + path-guard; real ~/.flowmcp never touched).

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)