### PR TITLE
Memo 099: CLI-Entschlackung / Friction-Abbau (schemaFolders, no add, graceful keys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,29 @@ Command-line tool for developing, validating, and managing FlowMCP schemas.
 
 ## Description
 
-FlowMCP CLI is a developer tool for working with FlowMCP schemas — structured API definitions that enable AI agents to interact with external services. The CLI provides schema validation, live API testing, repository imports, delta-based updates, and an MCP server mode for integration with AI agent frameworks like Claude Code.
+FlowMCP CLI is a developer tool for working with FlowMCP schemas — structured API definitions that enable AI agents to interact with external services. The CLI reads schemas directly from the folders you list in `schemaFolders[]` (one global config), makes every tool immediately callable (no activation step), provides schema validation, live API testing, and an MCP server mode for integration with AI agent frameworks like Claude Code.
 
 ## Architecture
 
 ```mermaid
-flowchart LR
-    A[Global: ~/.flowmcp/] --> B[Config + .env + Schemas]
-    B --> C[flowmcp init]
-    C --> D[Local: project/.flowmcp/]
-    D --> E[Groups with Selected Tools]
-    E --> F[flowmcp call / run]
+flowchart TD
+    A[~/.flowmcp/config.json] --> B{schemaFolders Array}
+    B --> C[name + path -> path/providers]
+    C --> D[Loader: all tools immediately available]
+    D --> E{requiredServerParams vs ~/.flowmcp/.env}
+    E -->|key present| F[tool active]
+    E -->|key missing| G[tool disabled: missing KEY visible]
+    F --> H[search / list / call]
+    G --> H
 ```
 
-| Level | Path | Content |
-|-------|------|---------|
-| **Global** | `~/.flowmcp/` | Config, .env with API keys, all imported schemas |
-| **Local** | `{project}/.flowmcp/` | Project config, groups with selected tools |
+One global config (`~/.flowmcp/config.json`) points — by path — directly at your schema folders. The folder on disk is the single source of truth: no copy, no registry, no per-project activation.
+
+| Setting | Path | Content |
+|---------|------|---------|
+| **Config** | `~/.flowmcp/config.json` | `envPath`, `schemaFolders[]`, `grading*` |
+| **Keys** | `~/.flowmcp/.env` | API keys (never in the repo) |
+| **Schemas** | `schemaFolders[].path` | Your schema repo (`providers/` + `selections/`) |
 
 ## Quickstart
 
@@ -32,6 +38,19 @@ cd flowmcp-cli
 npm i
 npx flowmcp init
 ```
+
+Then point the CLI at a schema folder by adding it to `~/.flowmcp/config.json`:
+
+```json
+{
+    "envPath": "~/.flowmcp/.env",
+    "schemaFolders": [
+        { "name": "development", "path": "~/path/to/flowmcp-schemas/schemas/v4.0.0" }
+    ]
+}
+```
+
+Every tool in every folder is now callable — no `add`. `path` may be `~`- or anchor-relative. A tool whose required API key is missing from `.env` is shown as `[disabled: missing KEY]` and skipped; all other tools stay usable.
 
 ## Commands
 
@@ -47,29 +66,18 @@ npx flowmcp init
 
 | Command | Description |
 |---------|-------------|
-| `flowmcp search <query>` | Find available tools by keyword |
-| `flowmcp add <tool-name>` | Activate a tool for this project |
-| `flowmcp remove <tool-name>` | Deactivate a tool |
-| `flowmcp reload <tool-name>` | Remove and re-add a tool (force refresh) |
-| `flowmcp list` | Show active tools |
+| `flowmcp search <query>` | Find tools by keyword (key-gated tools flagged `disabled`) |
+| `flowmcp list` | Show all tools from the configured schemaFolders (with `disabledCount`) |
+
+> No `add`/`remove`/`reload`/`group`: every tool in every configured folder is immediately available to `search`/`list`/`call`. To add or remove a folder, edit `schemaFolders[]` in `~/.flowmcp/config.json`.
 
 ### Schema Management
 
 | Command | Description |
 |---------|-------------|
-| `flowmcp schemas` | List all available schemas and their tools |
-| `flowmcp import <url> [--branch name]` | Import schemas from a GitHub repository |
-| `flowmcp import-registry <url>` | Import schemas from a registry URL |
-| `flowmcp update [source-name]` | Update schemas from remote registries (hash-based delta) |
+| `flowmcp schemas` | List all schemas (from the configured schemaFolders) and their tools |
 
-### Group Management
-
-| Command | Description |
-|---------|-------------|
-| `flowmcp group list` | List all groups and their tool counts |
-| `flowmcp group append <name> --tools "refs"` | Add tools to a group (creates group if new) |
-| `flowmcp group remove <name> --tools "refs"` | Remove tools from a group |
-| `flowmcp group set-default <name>` | Set the default group |
+> No `import`/`import-registry`/`update`: there is no registry or internet sync. Clone schema repos yourself (`gh repo clone …`) and add the path to `schemaFolders[]`.
 
 ### Prompt Management
 
@@ -221,11 +229,11 @@ flowmcp grading export providers/defillama
 
 | Command | Description |
 |---------|-------------|
-| `flowmcp call list-tools [--group name]` | List available tools in default/specified group |
-| `flowmcp call <tool-name> [json] [--group name]` | Call a tool with optional JSON input |
+| `flowmcp call list-tools` | List all available tools from the schemaFolders |
+| `flowmcp call <tool-name> [json]` | Call a tool with optional JSON input (no activation needed) |
 | `flowmcp call <tool-name> [json] --no-cache` | Call a tool bypassing cache |
 | `flowmcp call <tool-name> [json] --refresh` | Call a tool and refresh cache |
-| `flowmcp run [--group name]` | Start MCP server (stdio transport) |
+| `flowmcp run` | Start MCP server (stdio transport) |
 
 ## Tool Reference Format
 
@@ -305,7 +313,7 @@ Resolution happens in two steps: first check whether the env var is set; if not,
 
 ### Error `RES035`
 
-When the CLI cannot resolve a variable — for example because an unknown variable appears in the `path`, or an env var without a default is empty — `flowmcp add` aborts with `RES035`. Users fix this by setting the env var explicitly (`export FLOWMCP_RESOURCES=/path/to/dir`) or by moving the database to the default location.
+When the CLI cannot resolve a variable — for example because an unknown variable appears in the `path`, or an env var without a default is empty — a resource `call` aborts with `RES035`. Users fix this by setting the env var explicitly (`export FLOWMCP_RESOURCES=/path/to/dir`) or by moving the database to the default location.
 
 ### The `FLOWMCP_*` Name Family
 
@@ -315,7 +323,7 @@ Example for an alternative location:
 
 ```bash
 export FLOWMCP_RESOURCES=/Volumes/MyData/flowmcp
-flowmcp add gtfsde-transit-v2
+flowmcp call <tool-name>
 ```
 
 Related sections: [Add-ons](#add-ons) (schema examples with `${FLOWMCP_RESOURCES}`), [FlowMCP Directory Structure](#flowmcp-directory-structure) (default resolution).
@@ -337,7 +345,7 @@ The path from a provider feed to a database usable by FlowMCP has four steps:
 1. **Download** the GTFS feed from the provider (examples: `gtfs.de/de/feeds/`, regional open-data portals, provider-owned download pages)
 2. **Convert** via the `gtfs-sqlite-toolkit` add-on (see the add-on README for the exact invocation)
 3. **Store** the database at `${FLOWMCP_RESOURCES}/<name>.db` (default `~/.flowmcp/resources/<name>.db`)
-4. **Activate** via `flowmcp add <schema>`
+4. **Use** the schema — it is already available via `call`/`list` once its folder is in `schemaFolders[]` (no activation step)
 
 Concrete command examples:
 
@@ -352,8 +360,8 @@ node convert.mjs --input=~/Downloads/latest.zip --output=~/.flowmcp/resources/gt
 # 3. Optional: move the database to a different location
 #    (when ${FLOWMCP_RESOURCES} does not point at the default)
 
-# 4. Activate the schema
-flowmcp add gtfsde-transit-v2
+# 4. Call the tool directly (the schema's folder is in schemaFolders[])
+flowmcp call <tool-name>
 ```
 
 ### Pre-Push Protection
@@ -400,11 +408,7 @@ Related sections: [Path Variables](#path-variables) (resolution logic), [Data So
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--help` | `-h` | Show help |
-| `--group <name>` | | Target a specific group |
 | `--route <name>` | | Filter by route name (for test commands) |
-| `--branch <name>` | | Git branch for import |
-| `--tools "refs"` | | Comma-separated tool references (for group commands) |
-| `--force` | | Force overwrite (for add) |
 | `--no-cache` | | Bypass cache (for call) |
 | `--refresh` | | Refresh cached result (for call) |
 | `--all` | | Apply to all schemas (for migrate) |
@@ -418,26 +422,23 @@ Related sections: [Path Variables](#path-variables) (resolution logic), [Data So
 ### Basic Setup and Usage
 
 ```bash
-# 1. Setup (quick install imports schemas and creates default group)
+# 1. Setup
 flowmcp init
 
-# 2. Or: Manual import and group creation
-flowmcp import https://github.com/FlowMCP/flowmcp-schemas
-flowmcp group append crypto --tools "flowmcp-schemas/coingecko/simplePrice.mjs,flowmcp-schemas/etherscan/getBalance.mjs"
-flowmcp group set-default crypto
+# 2. Point the CLI at a schema folder (clone it yourself first):
+#    gh repo clone FlowMCP/flowmcp-schemas ~/flowmcp-schemas
+#    then add to ~/.flowmcp/config.json:
+#      "schemaFolders": [ { "name": "development", "path": "~/flowmcp-schemas/schemas/v4.0.0" } ]
 
-# 3. Validate and test
-flowmcp validate
-flowmcp test project
+# 3. Discover tools (all immediately available — no add)
+flowmcp search coingecko
+flowmcp list
 
-# 4. Use tools
+# 4. Use tools directly
 flowmcp call list-tools
-flowmcp call coingecko_simplePrice '{"ids":"bitcoin","vs_currencies":"usd"}'
+flowmcp call simple_price_coingecko '{"ids":"bitcoin","vs_currencies":"usd"}'
 
-# 5. Update schemas from remote
-flowmcp update
-
-# 6. Run as MCP server
+# 5. Run as MCP server
 flowmcp run
 ```
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -102,31 +102,8 @@ const runCommand = async () => {
         return true
     }
 
-    if( command === 'add' ) {
-        const toolName = positionals[ 1 ]
-        const force = values[ 'force' ] || false
-        const { result } = await FlowMcpCli.add( { toolName, cwd, force } )
-        output( { result } )
-
-        return true
-    }
-
-    if( command === 'reload' ) {
-        const toolName = positionals[ 1 ]
-        await FlowMcpCli.remove( { toolName, cwd } )
-        const { result } = await FlowMcpCli.add( { toolName, cwd, 'force': true } )
-        output( { result } )
-
-        return true
-    }
-
-    if( command === 'remove' ) {
-        const toolName = positionals[ 1 ]
-        const { result } = await FlowMcpCli.remove( { toolName, cwd } )
-        output( { result } )
-
-        return true
-    }
+    // Memo 099 Kap 5 — `add`/`reload`/`remove` removed. All tools from the
+    // configured schemaFolders are immediately available via search/list/call.
 
     if( command === 'list' ) {
         const { result } = await FlowMcpCli.list( { cwd } )
@@ -234,22 +211,9 @@ const runCommand = async () => {
         return true
     }
 
-    if( command === 'import' ) {
-        const url = positionals[ 1 ]
-        const branch = values[ 'branch' ] || 'main'
-        const { result } = await FlowMcpCli.import( { url, branch } )
-        output( { result } )
-
-        return true
-    }
-
-    if( command === 'import-registry' ) {
-        const registryUrl = positionals[ 1 ]
-        const { result } = await FlowMcpCli.importRegistry( { registryUrl } )
-        output( { result } )
-
-        return true
-    }
+    // Memo 099 Kap 7 — `import`/`import-registry` removed (no registry/internet sync).
+    // Add a schema folder by editing schemaFolders[] in ~/.flowmcp/config.json;
+    // clone repos yourself with `gh repo clone`.
 
     if( command === 'import-agent' ) {
         const agentName = positionals[ 1 ]
@@ -332,13 +296,7 @@ const runCommand = async () => {
         return true
     }
 
-    if( command === 'update' ) {
-        const sourceName = positionals[ 1 ] || undefined
-        const { result } = await FlowMcpCli.update( { sourceName } )
-        output( { result } )
-
-        return true
-    }
+    // Memo 099 Kap 7 — `update` removed (no registry polling / internet sync).
 
     if( command === 'schemas' ) {
         const { result } = await FlowMcpCli.schemas()
@@ -347,44 +305,8 @@ const runCommand = async () => {
         return true
     }
 
-    if( command === 'group' ) {
-        const subCommand = positionals[ 1 ]
-        const groupName = positionals[ 2 ]
-
-        if( subCommand === 'append' ) {
-            const tools = values[ 'tools' ]
-            const { result } = await FlowMcpCli.groupAppend( { 'name': groupName, tools, cwd } )
-            output( { result } )
-
-            return true
-        }
-
-        if( subCommand === 'remove' ) {
-            const tools = values[ 'tools' ]
-            const { result } = await FlowMcpCli.groupRemove( { 'name': groupName, tools, cwd } )
-            output( { result } )
-
-            return true
-        }
-
-        if( subCommand === 'list' ) {
-            const { result } = await FlowMcpCli.groupList( { cwd } )
-            output( { result } )
-
-            return true
-        }
-
-        if( subCommand === 'set-default' ) {
-            const { result } = await FlowMcpCli.groupSetDefault( { 'name': groupName, cwd } )
-            output( { result } )
-
-            return true
-        }
-
-        await FlowMcpCli.help( { cwd } )
-
-        return true
-    }
+    // Memo 099 Kap 5 — `group` removed (it was bound to the project-local config).
+    // `selection` remains for named display/filter subsets.
 
     if( command === 'prompt' ) {
         const subCommand = positionals[ 1 ]

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -5258,6 +5258,57 @@ class FlowMcpCli {
     }
 
 
+    // Memo 099 Kap 3 — resolve ~/anchor-relative schemaFolders paths (no hardcoded usernames)
+    static #resolvePath( { path } ) {
+        if( typeof path !== 'string' || path.length === 0 ) {
+            return { resolvedPath: path }
+        }
+
+        if( path === '~' ) {
+            return { resolvedPath: homedir() }
+        }
+
+        if( path.startsWith( '~/' ) === true ) {
+            const resolvedPath = join( homedir(), path.slice( 2 ) )
+
+            return { resolvedPath }
+        }
+
+        if( isAbsolute( path ) === true ) {
+            return { resolvedPath: path }
+        }
+
+        const resolvedPath = resolve( path )
+
+        return { resolvedPath }
+    }
+
+
+    // Memo 099 Kap 3/4 — read schemaFolders[] (name + resolved path) from the global config
+    static async #readSchemaFolders() {
+        const globalConfigPath = FlowMcpCli.#globalConfigPath()
+        const { data: globalConfig } = await FlowMcpCli.#readJson( { filePath: globalConfigPath } )
+        const raw = globalConfig && globalConfig[ 'schemaFolders' ]
+
+        if( raw === undefined || raw === null || Array.isArray( raw ) === false ) {
+            return { schemaFolders: [] }
+        }
+
+        const schemaFolders = raw
+            .filter( ( entry ) => entry && typeof entry === 'object' && Array.isArray( entry ) === false )
+            .filter( ( entry ) => typeof entry[ 'name' ] === 'string' && entry[ 'name' ].length > 0 )
+            .filter( ( entry ) => typeof entry[ 'path' ] === 'string' && entry[ 'path' ].length > 0 )
+            .map( ( entry ) => {
+                const { name, path } = entry
+                const { resolvedPath } = FlowMcpCli.#resolvePath( { path } )
+
+                return { name, 'path': resolvedPath }
+            } )
+
+        return { schemaFolders }
+    }
+
+
     static async #readLocalSources() {
         const globalConfigPath = FlowMcpCli.#globalConfigPath()
         const { data: globalConfig } = await FlowMcpCli.#readJson( { filePath: globalConfigPath } )
@@ -5282,6 +5333,17 @@ class FlowMcpCli {
 
 
     static async #resolveSourceDir( { sourceName } ) {
+        // Memo 099 Kap 4 — schemaFolders[] win: source dir = <path>/providers (direct, no disk-copy)
+        const { schemaFolders } = await FlowMcpCli.#readSchemaFolders()
+        const folder = schemaFolders
+            .find( ( entry ) => entry[ 'name' ] === sourceName )
+
+        if( folder !== undefined ) {
+            const sourceDir = join( folder[ 'path' ], 'providers' )
+
+            return { sourceDir, isLocal: true }
+        }
+
         const { localSources } = await FlowMcpCli.#readLocalSources()
         const local = localSources[ sourceName ]
 
@@ -7237,30 +7299,42 @@ class FlowMcpCli {
         const globalConfigPath = FlowMcpCli.#globalConfigPath()
         const { data: globalConfig } = await FlowMcpCli.#readJson( { filePath: globalConfigPath } )
         const configSources = ( globalConfig && globalConfig[ 'sources' ] ) || {}
-        const { localSources } = await FlowMcpCli.#readLocalSources()
 
-        let sourceDirs = []
-        try {
-            const entries = await readdir( schemasBaseDir )
-            const dirChecks = await entries
-                .reduce( ( promise, entry ) => promise.then( async ( acc ) => {
-                    const entryPath = join( schemasBaseDir, entry )
-                    const entryStat = await stat( entryPath )
-                    if( entryStat.isDirectory() ) {
-                        acc.push( entry )
-                    }
+        // Memo 099 Kap 4 — schemaFolders[] is the single source of truth (the disk = the truth).
+        // Legacy ~/.flowmcp/schemas scan + localSources are the fallback until migration (Memo 099 Kap 9).
+        const { schemaFolders } = await FlowMcpCli.#readSchemaFolders()
 
-                    return acc
-                } ), Promise.resolve( [] ) )
+        let allSourceNames = []
 
-            sourceDirs = dirChecks
-        } catch {
-            sourceDirs = []
+        if( schemaFolders.length > 0 ) {
+            allSourceNames = schemaFolders
+                .map( ( entry ) => entry[ 'name' ] )
+        } else {
+            const { localSources } = await FlowMcpCli.#readLocalSources()
+
+            let sourceDirs = []
+            try {
+                const entries = await readdir( schemasBaseDir )
+                const dirChecks = await entries
+                    .reduce( ( promise, entry ) => promise.then( async ( acc ) => {
+                        const entryPath = join( schemasBaseDir, entry )
+                        const entryStat = await stat( entryPath )
+                        if( entryStat.isDirectory() ) {
+                            acc.push( entry )
+                        }
+
+                        return acc
+                    } ), Promise.resolve( [] ) )
+
+                sourceDirs = dirChecks
+            } catch {
+                sourceDirs = []
+            }
+
+            const localSourceNames = Object.keys( localSources )
+                .filter( ( name ) => sourceDirs.includes( name ) === false )
+            allSourceNames = [ ...sourceDirs, ...localSourceNames ]
         }
-
-        const localSourceNames = Object.keys( localSources )
-            .filter( ( name ) => sourceDirs.includes( name ) === false )
-        const allSourceNames = [ ...sourceDirs, ...localSourceNames ]
 
         const sources = []
 

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -3056,6 +3056,16 @@ class FlowMcpCli {
         const { tools: allTools } = await FlowMcpCli.#listAvailableTools()
         const queryTokens = query.toLowerCase().trim().split( /\s+/ )
 
+        // Memo 099 Kap 6 — read env so search can flag key-gated (disabled) tools
+        const { config: searchConfig } = await FlowMcpCli.#readConfig( { cwd: process.cwd() } )
+        const searchEnvPath = searchConfig ? searchConfig[ 'envPath' ] : null
+        const { data: searchEnvContent } = searchEnvPath
+            ? await FlowMcpCli.#readText( { filePath: searchEnvPath } )
+            : { data: null }
+        const searchEnvObject = searchEnvContent
+            ? FlowMcpCli.#parseEnvFile( { envContent: searchEnvContent } ).envObject
+            : {}
+
         const { aliasIndex } = await FlowMcpCli.#loadSharedAliases()
         const sharedMatchRefs = new Set()
         aliasIndex
@@ -3085,7 +3095,7 @@ class FlowMcpCli {
                     tags,
                     score,
                     'type': tool[ 'type' ] || 'tool',
-                    'add': `${appConfig[ 'cliCommand' ]} add ${toolName}`,
+                    'call': `${appConfig[ 'cliCommand' ]} call ${toolName}`,
                     schemaRef,
                     routeName
                 }
@@ -3118,6 +3128,19 @@ class FlowMcpCli {
                     const { main } = await FlowMcpCli.#loadSchema( { filePath } )
 
                     if( main ) {
+                        // Memo 099 Kap 6 — flag tools whose required keys are missing
+                        const requiredKeys = main[ 'requiredServerParams' ] || []
+                        const missingKeys = requiredKeys
+                            .filter( ( key ) => {
+                                const present = searchEnvObject[ key ] !== undefined && String( searchEnvObject[ key ] ).length > 0
+
+                                return present === false
+                            } )
+                        if( missingKeys.length > 0 ) {
+                            tool[ 'disabled' ] = true
+                            tool[ 'disabledReason' ] = `missing ${missingKeys.join( ', ' )}`
+                        }
+
                         const { meta } = FlowMcpCli.#extractMetaFlags( { main, routeName } )
                         const { requiredParams, optionalParams } = FlowMcpCli.#extractParameterDetails( { main, routeName } )
                         const { example } = FlowMcpCli.#generateCallExample( { toolName, requiredParams } )
@@ -3648,54 +3671,9 @@ class FlowMcpCli {
             return { result }
         }
 
-        const { toolRefs } = await FlowMcpCli.#resolveActiveToolRefs( { cwd } )
-
-        // Memo 051 PRD-19 — auto-injected sqlite-gtfs tools come from the seal cache
-        // and are visible even when no traditional toolRefs are active.
-        if( toolRefs.length === 0 ) {
-            const { entries: sealCacheEntries } = await FlowMcpCli.#listSqliteGtfsCacheEntries()
-            const autoToolsOnly = []
-            sealCacheEntries
-                .forEach( ( entry ) => {
-                    const entryTools = entry && entry[ 'tools' ] ? entry[ 'tools' ] : []
-                    entryTools
-                        .forEach( ( tool ) => {
-                            autoToolsOnly.push( {
-                                'name': tool.name,
-                                'description': tool.description || '',
-                                'tags': [],
-                                'parameters': {},
-                                'auto': tool.auto === true,
-                                'schema': entry[ 'schemaName' ]
-                            } )
-                        } )
-                } )
-
-            const result = {
-                'status': true,
-                'toolCount': autoToolsOnly.length,
-                'tools': autoToolsOnly
-            }
-
-            return { result }
-        }
-
-        const legacyRefs = toolRefs
-            .filter( ( ref ) => {
-                const isLegacy = !FlowMcpCli.#isSpecId( { 'ref': ref } )
-
-                return isLegacy
-            } )
-
-        const specIdRefs = toolRefs
-            .filter( ( ref ) => {
-                const isSpec = FlowMcpCli.#isSpecId( { 'ref': ref } )
-
-                return isSpec
-            } )
-
-        const { schemas } = await FlowMcpCli.#resolveToolRefs( { 'toolRefs': legacyRefs } )
-
+        // Memo 099 Kap 5/6 — list ALL tools from the configured schemaFolders.
+        // A tool whose required keys are missing from .env is flagged disabled
+        // (visible, never hidden) so the user sees exactly what is unavailable.
         const { config } = await FlowMcpCli.#readConfig( { cwd } )
         const { envPath } = config
         const { data: envContent } = await FlowMcpCli.#readText( { filePath: envPath } )
@@ -3703,7 +3681,10 @@ class FlowMcpCli {
             ? FlowMcpCli.#parseEnvFile( { envContent } ).envObject
             : {}
 
+        const { schemas } = await FlowMcpCli.#resolveAllSchemas()
+
         const tools = []
+        let disabledCount = 0
 
         const sharedListsMap = {}
         await schemas
@@ -3726,6 +3707,15 @@ class FlowMcpCli {
                 const schemaTags = main[ 'tags' ] || []
                 const sharedLists = sharedListsMap[ file ] || {}
 
+                const requiredKeys = main[ 'requiredServerParams' ] || []
+                const missingKeys = requiredKeys
+                    .filter( ( key ) => {
+                        const present = envObject[ key ] !== undefined && String( envObject[ key ] ).length > 0
+
+                        return present === false
+                    } )
+                const disabled = missingKeys.length > 0
+
                 Object.keys( routes )
                     .forEach( ( routeName ) => {
                         try {
@@ -3736,31 +3726,19 @@ class FlowMcpCli {
                             const routeParameters = routeConfig[ 'parameters' ] || []
                             const { parameters } = FlowMcpCli.#extractParameters( { routeParameters, sharedLists } )
 
-                            tools.push( { name, description, 'tags': schemaTags, parameters } )
+                            const entry = { name, description, 'tags': schemaTags, parameters }
+                            if( disabled === true ) {
+                                entry[ 'disabled' ] = true
+                                entry[ 'disabledReason' ] = `missing ${missingKeys.join( ', ' )}`
+                                disabledCount += 1
+                            }
+
+                            tools.push( entry )
                         } catch {
                             // skip broken tools
                         }
                     } )
             } )
-
-        if( specIdRefs.length > 0 ) {
-            const { index } = await FlowMcpCli.getNamespaceIndex( { cwd } )
-
-            specIdRefs
-                .forEach( ( ref ) => {
-                    const toolEntry = index[ 'tools' ][ ref ]
-
-                    if( toolEntry ) {
-                        tools.push( {
-                            'name': ref,
-                            'specId': ref,
-                            'description': '',
-                            'tags': [],
-                            'parameters': {}
-                        } )
-                    }
-                } )
-        }
 
         // Memo 051 PRD-19 — include auto-injected tools from cached sqlite-gtfs schemas
         const { entries: sealCacheEntries } = await FlowMcpCli.#listSqliteGtfsCacheEntries()
@@ -3783,6 +3761,7 @@ class FlowMcpCli {
         const result = {
             'status': true,
             'toolCount': tools.length,
+            disabledCount,
             tools
         }
 

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -8412,26 +8412,29 @@ Setup:
 
 Tool Discovery:
   search <query>                      Find available tools
-  add <tool-name>                     Activate a tool for this project
-  remove <tool-name>                  Deactivate a tool
-  list                                Show active tools
+  list                                Show all tools from the configured schemaFolders
 
 Execution:
-  run                                 Start MCP server (stdio) for default group
-  call list-tools                     List available tools from default group
-  call <tool-name> [json]             Execute a tool call
+  run                                 Start MCP server (stdio)
+  call list-tools                     List all available tools
+  call <tool-name> [json]             Execute a tool call (no activation needed)
+
+Schema Folders (Memo 099):
+  Tools come directly from the folders listed in schemaFolders[] in
+  ~/.flowmcp/config.json. Add a folder by editing that array (name + path).
+  No "add"/"import" — every tool in every folder is immediately callable.
+  A tool whose required API key is missing is shown as
+  "[disabled: missing KEY]" and skipped; the rest stay usable.
 
 Development & Schema Maintenance:
   ${cmd} dev <subcommand>             See "${cmd} dev --help" for all dev commands
                                       (validate, test, allowlist, migrate-config,
-                                       selection, lists, schemas, import, update, status,
-                                       group, prompt, resource, etc.)
+                                       selection, lists, schemas, status,
+                                       prompt, resource, etc.)
 
 Options:
   --tools <list>              Comma-separated tool refs (source/file.mjs::route)
-  --group <name>              Override default group for run/call/validate/test
   --route <name>              Filter test to a single route
-  --branch <name>             Branch for import (default: main)
   --basis <name>              Override basis folder (default: flowmcp)
   --yes, -y                   Auto-confirm prompts
   --dry-run                   Preview changes without applying
@@ -8473,18 +8476,11 @@ Configuration:
   dev migrate-config                  Migrate config from v3 path::route format to v4 spec-IDs
 
 Schema Management:
-  dev schemas                         List all imported sources and schemas
-  dev import <github-url>             Import schemas from a GitHub repository
-  dev import-registry <url>           Import schemas from a custom registry URL
+  dev schemas                         List all schemas from the configured schemaFolders
   dev import-agent <url>              Import an agent manifest
-  dev update [source-name]            Update schemas from remote registries
-  dev status                          Show config, sources, groups and health info
-
-Group Management:
-  dev group append <name> --tools <list>     Add tools to a group
-  dev group remove <name> --tools <list>     Remove tools from a group
-  dev group list                             List all groups
-  dev group set-default <name>               Set the default group
+  dev status                          Show config, schemaFolders and health info
+  (Memo 099: import/import-registry/update removed — add a folder by editing
+   schemaFolders[] in ~/.flowmcp/config.json; clone repos with "gh repo clone")
 
 Prompt Management:
   dev prompt list                            List all prompts across all groups

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -2674,52 +2674,8 @@ class FlowMcpCli {
             return { result }
         }
 
-        let resolvedSchemas = null
-        let groupName = null
-
-        if( !group ) {
-            const { schemas: agentSchemas, error: agentError, fix: agentFix } = await FlowMcpCli.#resolveAgentSchemas( { cwd } )
-            if( !agentSchemas ) {
-                const result = FlowMcpCli.#error( { 'error': agentError, 'fix': agentFix } )
-
-                return { result }
-            }
-
-            resolvedSchemas = agentSchemas
-            groupName = '_default'
-        } else {
-            const { groupName: resolvedGroupName, error: groupNameError, fix: groupNameFix } = await FlowMcpCli.#resolveGroupName( { group, cwd } )
-            if( !resolvedGroupName ) {
-                const result = FlowMcpCli.#error( { 'error': groupNameError, 'fix': groupNameFix } )
-
-                return { result }
-            }
-
-            groupName = resolvedGroupName
-
-            const { schemas: groupSchemas, error: schemasError, fix: schemasFix } = await FlowMcpCli.#resolveGroupSchemas( { 'groupName': resolvedGroupName, cwd } )
-            if( !groupSchemas ) {
-                const result = FlowMcpCli.#error( { 'error': schemasError, 'fix': schemasFix } )
-
-                return { result }
-            }
-
-            resolvedSchemas = groupSchemas
-        }
-
-        const { config } = await FlowMcpCli.#readConfig( { cwd } )
-        const { envPath } = config
-        const { data: envContent } = await FlowMcpCli.#readText( { filePath: envPath } )
-        if( !envContent ) {
-            const result = FlowMcpCli.#error( {
-                'error': `Cannot read .env file at: ${envPath}`,
-                'fix': `Ensure the .env file exists at ${envPath}`
-            } )
-
-            return { result }
-        }
-
-        const { envObject } = FlowMcpCli.#parseEnvFile( { envContent } )
+        // Memo 099 Kap 5 — list ALL tools from the configured schemaFolders (no group/activation).
+        const { schemas: resolvedSchemas } = await FlowMcpCli.#resolveAllSchemas()
 
         const tools = []
 
@@ -2748,7 +2704,7 @@ class FlowMcpCli {
 
         const result = {
             'status': true,
-            'group': groupName,
+            'group': '_all',
             'toolCount': tools.length,
             tools
         }
@@ -2821,48 +2777,16 @@ class FlowMcpCli {
             resolvedToolName = mcpToolName
         }
 
-        let resolvedSchemas = null
-
-        if( !group ) {
-            const { schemas: agentSchemas, error: agentError, fix: agentFix } = await FlowMcpCli.#resolveAgentSchemas( { cwd } )
-            if( !agentSchemas ) {
-                const result = FlowMcpCli.#error( { 'error': agentError, 'fix': agentFix } )
-
-                return { result }
-            }
-
-            resolvedSchemas = agentSchemas
-        } else {
-            const { groupName, error: groupNameError, fix: groupNameFix } = await FlowMcpCli.#resolveGroupName( { group, cwd } )
-            if( !groupName ) {
-                const result = FlowMcpCli.#error( { 'error': groupNameError, 'fix': groupNameFix } )
-
-                return { result }
-            }
-
-            const { schemas: groupSchemas, error: schemasError, fix: schemasFix } = await FlowMcpCli.#resolveGroupSchemas( { groupName, cwd } )
-            if( !groupSchemas ) {
-                const result = FlowMcpCli.#error( { 'error': schemasError, 'fix': schemasFix } )
-
-                return { result }
-            }
-
-            resolvedSchemas = groupSchemas
-        }
+        // Memo 099 Kap 5 — no activation: resolve against ALL configured schemaFolders.
+        const { schemas: allSchemas } = await FlowMcpCli.#resolveAllSchemas()
+        const resolvedSchemas = allSchemas
 
         const { config } = await FlowMcpCli.#readConfig( { cwd } )
         const { envPath } = config
         const { data: envContent } = await FlowMcpCli.#readText( { filePath: envPath } )
-        if( !envContent ) {
-            const result = FlowMcpCli.#error( {
-                'error': `Cannot read .env file at: ${envPath}`,
-                'fix': `Ensure the .env file exists at ${envPath}`
-            } )
-
-            return { result }
-        }
-
-        const { envObject } = FlowMcpCli.#parseEnvFile( { envContent } )
+        const envObject = envContent
+            ? FlowMcpCli.#parseEnvFile( { envContent } ).envObject
+            : {}
 
         let userParams = {}
         if( jsonArgs ) {
@@ -2923,8 +2847,29 @@ class FlowMcpCli {
             }
 
             const result = FlowMcpCli.#error( {
-                'error': `Tool "${toolName}" not found in active tools.`,
-                'fix': `Run ${appConfig[ 'cliCommand' ]} call list-tools to see available tool names.`
+                'error': `Tool "${toolName}" not found.`,
+                'fix': `Run ${appConfig[ 'cliCommand' ]} search <query> or ${appConfig[ 'cliCommand' ]} list to see available tool names.`
+            } )
+
+            return { result }
+        }
+
+        // Memo 099 Kap 6 — graceful degradation: a tool whose required keys are
+        // missing is disabled, never a global abort. The other tools stay usable.
+        const matchedRequiredKeys = matchedMain[ 'requiredServerParams' ] || []
+        const matchedMissingKeys = matchedRequiredKeys
+            .filter( ( key ) => {
+                const present = envObject[ key ] !== undefined && String( envObject[ key ] ).length > 0
+
+                return present === false
+            } )
+
+        if( matchedMissingKeys.length > 0 ) {
+            const { tools: availableTools } = await FlowMcpCli.#listAvailableTools()
+            const otherCount = availableTools.length > 0 ? availableTools.length - 1 : 0
+            const result = FlowMcpCli.#error( {
+                'error': `Tool "${toolName}" is not available — missing key(s): ${matchedMissingKeys.join( ', ' )}.`,
+                'fix': `Add the key(s) to ${envPath}. ${otherCount} other tool(s) remain callable.`
             } )
 
             return { result }
@@ -10149,6 +10094,38 @@ allowlist, migrate-config, etc.).
         const { schemas } = await FlowMcpCli.#resolveToolRefs( { toolRefs } )
 
         return { schemas, 'error': null, 'fix': null }
+    }
+
+
+    // Memo 099 Kap 5 — load ALL schemas from the configured schemaFolders[].
+    // No activation: every tool in every folder is immediately resolvable.
+    static async #resolveAllSchemas() {
+        const { sources } = await FlowMcpCli.#listSources()
+        const schemas = []
+
+        await sources
+            .reduce( ( promise, source ) => promise.then( async () => {
+                const { name: sourceName, schemas: sourceSchemas } = source
+
+                await sourceSchemas
+                    .reduce( ( schemaPromise, schemaEntry ) => schemaPromise.then( async () => {
+                        const { file, requiredServerParams } = schemaEntry
+                        const schemaRef = `${sourceName}/${file}`
+                        const { filePath } = await FlowMcpCli.#resolveSchemaPath( { schemaRef } )
+                        const { main, handlersFn } = await FlowMcpCli.#loadSchema( { filePath } )
+
+                        if( main ) {
+                            schemas.push( {
+                                main,
+                                handlersFn,
+                                'file': schemaRef,
+                                'requiredServerParams': Array.isArray( requiredServerParams ) ? requiredServerParams : ( main[ 'requiredServerParams' ] || [] )
+                            } )
+                        }
+                    } ), Promise.resolve() )
+            } ), Promise.resolve() )
+
+        return { schemas }
     }
 
 

--- a/tests/unit/add-force-calltool-cache.test.mjs
+++ b/tests/unit/add-force-calltool-cache.test.mjs
@@ -289,14 +289,15 @@ describe( 'FlowMcpCli.callListTools with group override', () => {
     } )
 
 
-    test( 'lists tools from specified group', async () => {
+    // Memo 099 Kap 5 — group is removed; call list-tools lists ALL tools.
+    test( 'ignores the group param and lists all tools', async () => {
         const { result } = await FlowMcpCli.callListTools( {
             'group': 'alternate-group',
             'cwd': CWD
         } )
 
         expect( result[ 'status' ] ).toBe( true )
-        expect( result[ 'group' ] ).toBe( 'alternate-group' )
+        expect( result[ 'group' ] ).toBe( '_all' )
         expect( result[ 'toolCount' ] ).toBeGreaterThan( 0 )
 
         const toolNames = result[ 'tools' ]
@@ -310,14 +311,14 @@ describe( 'FlowMcpCli.callListTools with group override', () => {
     } )
 
 
-    test( 'returns error for non-existent group', async () => {
+    test( 'ignores a non-existent group and still lists all tools', async () => {
         const { result } = await FlowMcpCli.callListTools( {
             'group': 'nonexistent',
             'cwd': CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( 'not found' )
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'group' ] ).toBe( '_all' )
     } )
 } )
 

--- a/tests/unit/call-list-tools.test.mjs
+++ b/tests/unit/call-list-tools.test.mjs
@@ -175,18 +175,22 @@ describe( 'FlowMcpCli.callListTools', () => {
     } )
 
 
-    it( 'returns tools for a named group', async () => {
+    // Memo 099 Kap 5 — group is removed; the param is ignored and all tools list.
+    it( 'ignores a named group and lists all tools', async () => {
         const { result } = await FlowMcpCli.callListTools( { group: 'named-group', cwd: TEST_CWD } )
 
         expect( result[ 'status' ] ).toBe( true )
-        expect( result[ 'group' ] ).toBe( 'named-group' )
-        expect( result[ 'toolCount' ] ).toBe( 1 )
-        expect( result[ 'tools' ].length ).toBe( 1 )
-        expect( result[ 'tools' ][ 0 ][ 'toolName' ] ).toBe( 'get_status_callapi' )
+        expect( result[ 'group' ] ).toBe( '_all' )
+
+        const toolNames = result[ 'tools' ]
+            .map( ( tool ) => tool[ 'toolName' ] )
+
+        expect( toolNames ).toContain( 'get_status_callapi' )
     } )
 
 
-    it( 'returns error when env file is missing', async () => {
+    // Memo 099 Kap 5 — listing tools does not read .env; a missing env is fine.
+    it( 'does not require .env to list tools', async () => {
         const noEnvCwd = join( tmpdir(), 'flowmcp-cli-call-no-env-test' )
         const noEnvLocalDir = join( noEnvCwd, '.flowmcp' )
         await mkdir( noEnvLocalDir, { recursive: true } )
@@ -205,8 +209,7 @@ describe( 'FlowMcpCli.callListTools', () => {
 
         const { result } = await FlowMcpCli.callListTools( { group: undefined, cwd: noEnvCwd } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( 'Cannot read .env file' )
+        expect( result[ 'status' ] ).toBe( true )
 
         await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( TEST_GLOBAL_CONFIG, null, 4 ), 'utf-8' )
         await rm( noEnvCwd, { recursive: true, force: true } )
@@ -223,14 +226,18 @@ describe( 'FlowMcpCli.callTool', () => {
     } )
 
 
-    it( 'returns error when no local config exists', async () => {
+    // Memo 099 Kap 5 — no local config / activation is required anymore. A missing
+    // local config is NOT itself an error; tools resolve against the schemaFolders.
+    it( 'does not require a local config to resolve tools', async () => {
         const emptyCwd = join( tmpdir(), 'flowmcp-cli-call-empty-cwd' )
         await mkdir( emptyCwd, { recursive: true } )
 
-        const { result } = await FlowMcpCli.callTool( { toolName: 'get_status_callapi', jsonArgs: undefined, group: undefined, cwd: emptyCwd } )
+        const { result } = await FlowMcpCli.callTool( { toolName: 'nonexistent_tool_xyz', jsonArgs: undefined, group: undefined, cwd: emptyCwd } )
 
+        // resolves the folder index and reports "not found" — never "no active tools"
         expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
+        expect( result[ 'error' ] ).toContain( 'not found' )
+        expect( result[ 'error' ] ).not.toContain( 'active tools' )
 
         await rm( emptyCwd, { recursive: true, force: true } )
     } )

--- a/tests/unit/calltool-cache-flow.test.mjs
+++ b/tests/unit/calltool-cache-flow.test.mjs
@@ -283,8 +283,8 @@ describe( 'FlowMcpCli.callTool env missing path', () => {
             'cwd': badEnvCwd
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( '.env' )
+        // Memo 099 Kap 6 — graceful: keyless tool still resolves with empty env
+        expect( result[ 'status' ] ).toBe( true )
 
         const restoredConfig = JSON.parse( savedConfig )
         restoredConfig[ 'envPath' ] = ENV_PATH
@@ -328,8 +328,8 @@ describe( 'FlowMcpCli.callListTools env missing path', () => {
             'cwd': badEnvCwd
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( '.env' )
+        // Memo 099 Kap 5 — listing tools no longer needs .env; it lists all schemaFolders tools
+        expect( result[ 'status' ] ).toBe( true )
 
         const restoredConfig = JSON.parse( savedConfig )
         restoredConfig[ 'envPath' ] = ENV_PATH

--- a/tests/unit/calltool-edge-paths.test.mjs
+++ b/tests/unit/calltool-edge-paths.test.mjs
@@ -279,14 +279,16 @@ describe( 'FlowMcpCli.callTool — with group param for non-existent group', () 
     } )
 
 
-    it( 'returns error for nonexistent group name', async () => {
+    // Memo 099 Kap 5 — group is removed; the group param is ignored and the
+    // tool resolves against all schemaFolders regardless of any group value.
+    it( 'ignores the group param and resolves the tool', async () => {
         const { result } = await FlowMcpCli.callTool( {
             'toolName': 'ping_calledgesrc',
             'group': 'nonexistent-group',
             'cwd': CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'status' ] ).toBe( true )
     } )
 } )
 
@@ -318,7 +320,9 @@ describe( 'FlowMcpCli.callTool — env file missing', () => {
     } )
 
 
-    it( 'returns error when env file cannot be read', async () => {
+    // Memo 099 Kap 6 — graceful degradation: a missing .env no longer hard-fails
+    // the whole call. A keyless tool still resolves (env treated as empty).
+    it( 'does not hard-fail when env file cannot be read (keyless tool)', async () => {
         const savedConfig = await readFile( GLOBAL_CONFIG_PATH, 'utf-8' )
         const parsed = JSON.parse( savedConfig )
         parsed[ 'envPath' ] = '/tmp/nonexistent-calledge-env.env'
@@ -329,11 +333,10 @@ describe( 'FlowMcpCli.callTool — env file missing', () => {
             'cwd': CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( 'Cannot read .env' )
+        expect( result[ 'status' ] ).toBe( true )
 
         await writeFile( GLOBAL_CONFIG_PATH, savedConfig, 'utf-8' )
-    } )
+    }, 15000 )
 } )
 
 

--- a/tests/unit/disabled-flag-display.test.mjs
+++ b/tests/unit/disabled-flag-display.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { writeFile, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createTestHome } from '../helpers/test-home.mjs'
+
+const { FlowMcpCli } = await import( '../../src/task/FlowMcpCli.mjs' )
+
+
+// Memo 099 Phase 3 — a tool whose requiredServerParams are missing from the
+// .env is flagged disabled (visible, never hidden) in both list and search.
+const testHome = createTestHome( { suite: 'disabled-flag' } )
+const GLOBAL_CONFIG_PATH = testHome.globalConfigPath
+
+const KEYLESS_SCHEMA = `export const main = {
+    namespace: 'freeapi',
+    name: 'Free API',
+    description: 'A keyless tool that is always available',
+    version: '4.0.0',
+    docs: [], tags: [ 'free' ], root: 'https://httpbin.org',
+    requiredServerParams: [],
+    headers: {},
+    tools: { ping: { method: 'GET', description: 'free ping', path: '/get', parameters: [], tests: [] } }
+}
+`
+
+const KEYED_SCHEMA = `export const main = {
+    namespace: 'paidapi',
+    name: 'Paid API',
+    description: 'A tool that needs an API key',
+    version: '4.0.0',
+    docs: [], tags: [ 'paid' ], root: 'https://api.example.com',
+    requiredServerParams: [ 'PAID_API_KEY' ],
+    headers: { 'Authorization': 'Bearer {{PAID_API_KEY}}' },
+    tools: { fetchData: { method: 'GET', description: 'paid fetch data', path: '/data', parameters: [], tests: [] } }
+}
+`
+
+
+beforeAll( async () => {
+    await testHome.setup()
+
+    const globalConfig = {
+        'envPath': join( testHome.globalConfigDir, '.env' ),
+        'initialized': '2026-06-03T12:00:00.000Z',
+        'schemaFolders': [
+            { 'name': 'development', 'path': join( testHome.root, 'schemas', 'v4.0.0' ) }
+        ]
+    }
+    await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( globalConfig, null, 4 ), 'utf-8' )
+    // empty env — PAID_API_KEY is absent
+    await writeFile( join( testHome.globalConfigDir, '.env' ), '', 'utf-8' )
+
+    const providersDir = join( testHome.root, 'schemas', 'v4.0.0', 'providers' )
+    await mkdir( join( providersDir, 'freeapi' ), { recursive: true } )
+    await mkdir( join( providersDir, 'paidapi' ), { recursive: true } )
+    await writeFile( join( providersDir, 'freeapi', 'free.mjs' ), KEYLESS_SCHEMA, 'utf-8' )
+    await writeFile( join( providersDir, 'paidapi', 'paid.mjs' ), KEYED_SCHEMA, 'utf-8' )
+} )
+
+afterAll( async () => {
+    await testHome.teardown()
+} )
+
+
+describe( 'Memo 099 — disabled-flag display (missing keys)', () => {
+    it( 'list flags the key-gated tool as disabled and leaves the keyless one enabled', async () => {
+        const { result } = await FlowMcpCli.list( { cwd: testHome.root } )
+
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'disabledCount' ] ).toBeGreaterThanOrEqual( 1 )
+
+        const paid = result[ 'tools' ]
+            .find( ( tool ) => tool[ 'name' ].includes( 'fetch_data' ) || tool[ 'name' ].includes( 'paidapi' ) )
+        const free = result[ 'tools' ]
+            .find( ( tool ) => tool[ 'name' ].includes( 'ping' ) && tool[ 'name' ].includes( 'freeapi' ) )
+
+        expect( paid ).toBeDefined()
+        expect( paid[ 'disabled' ] ).toBe( true )
+        expect( paid[ 'disabledReason' ] ).toContain( 'PAID_API_KEY' )
+
+        expect( free ).toBeDefined()
+        expect( free[ 'disabled' ] ).toBeUndefined()
+    } )
+
+
+    it( 'search flags the key-gated tool as disabled', async () => {
+        const { result } = await FlowMcpCli.search( { query: 'paidapi paid' } )
+
+        expect( result[ 'status' ] ).toBe( true )
+
+        const paid = result[ 'tools' ]
+            .find( ( tool ) => tool[ 'namespace' ] === 'paidapi' )
+
+        expect( paid ).toBeDefined()
+        expect( paid[ 'disabled' ] ).toBe( true )
+        expect( paid[ 'disabledReason' ] ).toContain( 'PAID_API_KEY' )
+    } )
+
+
+    it( 'call on a disabled tool returns a friendly error, not a global abort', async () => {
+        const { result } = await FlowMcpCli.callTool( { toolName: 'fetch_data_paidapi', jsonArgs: '{}', cwd: testHome.root } )
+
+        expect( result[ 'status' ] ).toBe( false )
+        expect( result[ 'error' ] ).toContain( 'PAID_API_KEY' )
+        expect( result[ 'fix' ] ).toContain( 'remain callable' )
+    } )
+} )

--- a/tests/unit/remove-and-misc-paths.test.mjs
+++ b/tests/unit/remove-and-misc-paths.test.mjs
@@ -329,12 +329,13 @@ describe( 'FlowMcpCli.list — broken toolRef schema returns null main', () => {
     } )
 
 
-    it( 'returns an empty tool list when the only toolRef points to a nonexistent schema', async () => {
+    // Memo 099 Kap 5 — list reads the schemaFolders, not local active toolRefs;
+    // a broken local toolRef is irrelevant and the folder tools are still listed.
+    it( 'lists folder tools and ignores a broken local toolRef', async () => {
         const { result } = await FlowMcpCli.list( { 'cwd': CWD } )
 
         expect( result[ 'status' ] ).toBe( true )
-        expect( result[ 'toolCount' ] ).toBe( 0 )
-        expect( result[ 'tools' ] ).toHaveLength( 0 )
+        expect( result[ 'toolCount' ] ).toBeGreaterThan( 0 )
     } )
 } )
 

--- a/tests/unit/schema-folders-loader.test.mjs
+++ b/tests/unit/schema-folders-loader.test.mjs
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { writeFile, mkdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createTestHome } from '../helpers/test-home.mjs'
+
+const { FlowMcpCli } = await import( '../../src/task/FlowMcpCli.mjs' )
+
+
+// Memo 099 Phase 1 — schemaFolders[] loader. The global home mock points
+// homedir() at testHome.root, so a "~/..." schemaFolders path resolves into
+// the isolated test home. We exercise the private loader through the public
+// search() command (which reads #listSources -> #listAvailableTools).
+const testHome = createTestHome( { suite: 'schema-folders' } )
+const GLOBAL_CONFIG_PATH = testHome.globalConfigPath
+
+const DEMO_SCHEMA = `export const main = {
+    namespace: 'folderdemo',
+    name: 'Folder Demo API',
+    description: 'Schema loaded directly from a schemaFolders path',
+    version: '4.0.0',
+    docs: [],
+    tags: [ 'folder', 'demo' ],
+    root: 'https://httpbin.org',
+    requiredServerParams: [],
+    headers: {},
+    tools: {
+        ping: {
+            method: 'GET',
+            description: 'Folder ping endpoint',
+            path: '/get',
+            parameters: [],
+            tests: [ { _description: 'ping' } ]
+        }
+    }
+}
+`
+
+const SKIPPED_SCHEMA = `export const main = {
+    namespace: 'shouldskip',
+    name: 'Should Be Skipped',
+    description: 'Lives under a _-prefixed dir and must not be loaded',
+    version: '4.0.0',
+    docs: [],
+    tags: [ 'skip' ],
+    root: 'https://example.com',
+    requiredServerParams: [],
+    headers: {},
+    tools: {
+        nope: { method: 'GET', description: 'must not appear', path: '/x', parameters: [], tests: [] }
+    }
+}
+`
+
+
+beforeAll( async () => {
+    await testHome.setup()
+
+    // schemaFolders path uses ~ — resolves to testHome.root via the mocked homedir()
+    const globalConfig = {
+        'envPath': join( testHome.globalConfigDir, '.env' ),
+        'initialized': '2026-06-03T12:00:00.000Z',
+        'schemaFolders': [
+            { 'name': 'development', 'path': '~/myschemas/v4.0.0' }
+        ]
+    }
+    await writeFile( GLOBAL_CONFIG_PATH, JSON.stringify( globalConfig, null, 4 ), 'utf-8' )
+    await writeFile( join( testHome.globalConfigDir, '.env' ), '', 'utf-8' )
+
+    const providersDir = join( testHome.root, 'myschemas', 'v4.0.0', 'providers' )
+    const demoDir = join( providersDir, 'folderdemo' )
+    await mkdir( demoDir, { recursive: true } )
+    await writeFile( join( demoDir, 'demo.mjs' ), DEMO_SCHEMA, 'utf-8' )
+
+    // a _-prefixed dir under providers must be skipped by the loader
+    const skipDir = join( providersDir, '_shared' )
+    await mkdir( skipDir, { recursive: true } )
+    await writeFile( join( skipDir, 'ignore.mjs' ), SKIPPED_SCHEMA, 'utf-8' )
+} )
+
+afterAll( async () => {
+    await testHome.teardown()
+} )
+
+
+describe( 'Memo 099 — schemaFolders[] loader', () => {
+    it( 'loads tools from the configured schemaFolders path (~ resolved)', async () => {
+        const { result } = await FlowMcpCli.search( { query: 'folderdemo' } )
+
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'matchCount' ] ).toBeGreaterThan( 0 )
+
+        const names = result[ 'tools' ]
+            .map( ( tool ) => tool[ 'name' ] )
+        const hasPing = names
+            .some( ( name ) => name.includes( 'ping' ) && name.includes( 'folderdemo' ) )
+
+        expect( hasPing ).toBe( true )
+    } )
+
+
+    it( 'assigns the schemaFolders name as namespace source', async () => {
+        const { result } = await FlowMcpCli.search( { query: 'Folder ping endpoint' } )
+
+        expect( result[ 'status' ] ).toBe( true )
+
+        const pingTool = result[ 'tools' ]
+            .find( ( tool ) => tool[ 'namespace' ] === 'folderdemo' )
+
+        expect( pingTool ).toBeDefined()
+    } )
+
+
+    it( 'skips schemas under _-prefixed directories (_shared/_lists)', async () => {
+        const { result } = await FlowMcpCli.search( { query: 'shouldskip' } )
+
+        expect( result[ 'status' ] ).toBe( true )
+
+        const leaked = result[ 'tools' ]
+            .some( ( tool ) => tool[ 'namespace' ] === 'shouldskip' )
+
+        expect( leaked ).toBe( false )
+    } )
+} )

--- a/tests/unit/search-add-remove-list.test.mjs
+++ b/tests/unit/search-add-remove-list.test.mjs
@@ -199,7 +199,7 @@ describe( 'FlowMcpCli.search', () => {
         expect( firstTool ).toHaveProperty( 'description' )
         expect( firstTool ).toHaveProperty( 'namespace' )
         expect( firstTool ).toHaveProperty( 'score' )
-        expect( firstTool ).toHaveProperty( 'add' )
+        expect( firstTool ).toHaveProperty( 'call' )
         expect( firstTool[ 'score' ] ).toBeGreaterThan( 0 )
     } )
 
@@ -366,15 +366,16 @@ describe( 'FlowMcpCli.add', () => {
 
 
 describe( 'FlowMcpCli.list', () => {
-    it( 'returns empty tools when no local config exists', async () => {
+    // Memo 099 Kap 5 — list shows ALL tools from the schemaFolders, independent
+    // of any local config. A missing local config no longer yields an empty list.
+    it( 'lists all folder tools regardless of local config', async () => {
         const emptyCwd = join( tmpdir(), 'flowmcp-cli-list-empty' )
         await mkdir( emptyCwd, { recursive: true } )
 
         const { result } = await FlowMcpCli.list( { cwd: emptyCwd } )
 
         expect( result[ 'status' ] ).toBe( true )
-        expect( result[ 'toolCount' ] ).toBe( 0 )
-        expect( result[ 'tools' ] ).toHaveLength( 0 )
+        expect( result[ 'toolCount' ] ).toBeGreaterThan( 0 )
 
         await rm( emptyCwd, { recursive: true, force: true } )
     } )

--- a/tests/unit/spec-id-dispatch.test.mjs
+++ b/tests/unit/spec-id-dispatch.test.mjs
@@ -377,8 +377,10 @@ describe( 'search — results include specId field', () => {
 
 // ─── 11. list displays Spec-IDs from config ───────────────────────────────────
 
-describe( 'list — Spec-ID entries in config', () => {
-    it( 'includes Spec-ID entry in output when config has a Spec-ID ref', async () => {
+// Memo 099 Kap 5 — list shows ALL tools from the schemaFolders by their MCP
+// tool name (no per-config spec-id entries). The ping tool is listed regardless.
+describe( 'list — shows folder tools by MCP name (Memo 099)', () => {
+    it( 'lists the ping tool from the folder index', async () => {
         const cwd = await makeTmpCwdWithConfig( {
             'tools': [ 'demo/tool/ping' ],
             'suffix': 'list-specid'
@@ -388,15 +390,10 @@ describe( 'list — Spec-ID entries in config', () => {
 
         expect( result[ 'status' ] ).toBe( true )
 
-        const specEntry = result[ 'tools' ]
-            .find( ( t ) => {
-                const isSpecId = t[ 'specId' ] === 'demo/tool/ping'
+        const pingEntry = result[ 'tools' ]
+            .find( ( t ) => t[ 'name' ] && t[ 'name' ].includes( 'ping' ) )
 
-                return isSpecId
-            } )
-
-        expect( specEntry ).toBeDefined()
-        expect( specEntry[ 'name' ] ).toBe( 'demo/tool/ping' )
+        expect( pingEntry ).toBeDefined()
 
         await rm( cwd, { recursive: true, force: true } )
     } )

--- a/tests/unit/spec-id-dispatch.test.mjs
+++ b/tests/unit/spec-id-dispatch.test.mjs
@@ -347,7 +347,7 @@ describe( 'callTool — Spec-ID 2-slash dispatches via index', () => {
         // The tool exists (ping.mjs has no requiredServerParams but env is empty)
         // We expect either a successful call or a missing env error,
         // NOT a "not found" error — which confirms the Spec-ID was resolved correctly.
-        const isNotFoundError = result[ 'error' ] && result[ 'error' ].includes( 'not found in active tools' )
+        const isNotFoundError = Boolean( result[ 'error' ] && result[ 'error' ].includes( 'not found' ) )
 
         expect( isNotFoundError ).toBe( false )
 

--- a/tests/unit/status-and-config-deep-paths.test.mjs
+++ b/tests/unit/status-and-config-deep-paths.test.mjs
@@ -300,7 +300,9 @@ describe( 'callTool — no group and no active tools (lines 4636-4649)', () => {
         await rm( TEST_CWD, { recursive: true, force: true } ).catch( () => {} )
     } )
 
-    it( 'returns error when group is undefined and no defaultGroup or active tools exist', async () => {
+    // Memo 099 Kap 5 — no activation: with no defaultGroup or active tools, the
+    // tool still resolves against the schemaFolders (keyless ping succeeds).
+    it( 'resolves the tool without any active tools or group', async () => {
         const { result } = await FlowMcpCli.callTool( {
             'toolName': 'ping_deepcfgsrc',
             'jsonArgs': '{}',
@@ -308,9 +310,8 @@ describe( 'callTool — no group and no active tools (lines 4636-4649)', () => {
             'cwd': TEST_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-    } )
+        expect( result[ 'status' ] ).toBe( true )
+    }, 15000 )
 } )
 
 

--- a/tests/unit/test-method-deep-paths.test.mjs
+++ b/tests/unit/test-method-deep-paths.test.mjs
@@ -329,46 +329,45 @@ describe( 'FlowMcpCli.test with schemaPath — config returns null', () => {
 // FlowMcpCli.callListTools — no active tools (lines 2177-2180)
 // ---------------------------------------------------------------------------
 
-describe( 'FlowMcpCli.callListTools — no active tools', () => {
-    it( 'returns No active tools error when local config has an empty tools array', async () => {
+// Memo 099 Kap 5 — call list-tools lists ALL tools from the schemaFolders.
+// There is no activation/group gate, so an empty/absent local config is fine.
+describe( 'FlowMcpCli.callListTools — no activation required (Memo 099)', () => {
+    it( 'lists all tools when local config has an empty tools array', async () => {
         const { result } = await FlowMcpCli.callListTools( {
             'group': undefined,
             'cwd': EMPTY_TOOLS_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-        expect( result[ 'error' ] ).toContain( 'No active tools' )
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'group' ] ).toBe( '_all' )
     } )
 
 
-    it( 'returns No active tools error when cwd has no local config at all', async () => {
+    it( 'lists all tools when cwd has no local config at all', async () => {
         const { result } = await FlowMcpCli.callListTools( {
             'group': undefined,
             'cwd': NO_CONFIG_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-        expect( result[ 'error' ] ).toContain( 'No active tools' )
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'group' ] ).toBe( '_all' )
     } )
 } )
 
 
 // ---------------------------------------------------------------------------
-// FlowMcpCli.callListTools — group schemas resolution failure (lines 2196-2199)
+// Memo 099 Kap 5 — group is removed; the group param is ignored.
 // ---------------------------------------------------------------------------
 
-describe( 'FlowMcpCli.callListTools — nonexistent group', () => {
-    it( 'returns group not found error when group name does not exist in local config', async () => {
+describe( 'FlowMcpCli.callListTools — group param ignored (Memo 099)', () => {
+    it( 'ignores a nonexistent group and still lists all tools', async () => {
         const { result } = await FlowMcpCli.callListTools( {
             'group': 'totally-nonexistent-group',
             'cwd': GROUP_MISSING_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-        expect( result[ 'error' ] ).toContain( 'totally-nonexistent-group' )
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'group' ] ).toBe( '_all' )
     } )
 } )
 
@@ -377,8 +376,10 @@ describe( 'FlowMcpCli.callListTools — nonexistent group', () => {
 // FlowMcpCli.callTool — group schemas resolution failure (lines 2292-2295)
 // ---------------------------------------------------------------------------
 
-describe( 'FlowMcpCli.callTool — nonexistent group', () => {
-    it( 'returns group not found error when group name does not exist in local config', async () => {
+// Memo 099 Kap 5 — group is removed. The group param is ignored; the tool
+// resolves against the schemaFolders regardless of any (non-)existent group.
+describe( 'FlowMcpCli.callTool — group param ignored (Memo 099)', () => {
+    it( 'ignores a nonexistent group name and resolves the tool', async () => {
         const { result } = await FlowMcpCli.callTool( {
             'toolName': 'ping_deeptest',
             'jsonArgs': undefined,
@@ -386,13 +387,11 @@ describe( 'FlowMcpCli.callTool — nonexistent group', () => {
             'cwd': GROUP_MISSING_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-        expect( result[ 'error' ] ).toContain( 'totally-nonexistent-group' )
-    } )
+        expect( result[ 'status' ] ).toBe( true )
+    }, 15000 )
 
 
-    it( 'returns error when group name is valid but cwd has no local config', async () => {
+    it( 'ignores the group param even when cwd has no local config', async () => {
         const { result } = await FlowMcpCli.callTool( {
             'toolName': 'ping_deeptest',
             'jsonArgs': undefined,
@@ -400,7 +399,6 @@ describe( 'FlowMcpCli.callTool — nonexistent group', () => {
             'cwd': NO_CONFIG_CWD
         } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toBeDefined()
-    } )
+        expect( result[ 'status' ] ).toBe( true )
+    }, 15000 )
 } )

--- a/tests/unit/test-route-filter-and-validate-catch.test.mjs
+++ b/tests/unit/test-route-filter-and-validate-catch.test.mjs
@@ -372,15 +372,16 @@ describe( 'FlowMcpCli.list — schema with no routes exercises line 2870', () =>
 } )
 
 
-describe( 'FlowMcpCli.callListTools — no active tools in empty cwd', () => {
-    it( 'returns error when cwd has no local config at all', async () => {
+// Memo 099 Kap 5 — no activation required; an empty cwd still lists all tools.
+describe( 'FlowMcpCli.callListTools — empty cwd lists all (Memo 099)', () => {
+    it( 'lists all tools even when cwd has no local config', async () => {
         const emptyCwd = join( tmpdir(), `flowmcp-listtools-empty-${Date.now()}` )
         await mkdir( emptyCwd, { recursive: true } )
 
         const { result } = await FlowMcpCli.callListTools( { 'cwd': emptyCwd } )
 
-        expect( result[ 'status' ] ).toBe( false )
-        expect( result[ 'error' ] ).toContain( 'No active tools' )
+        expect( result[ 'status' ] ).toBe( true )
+        expect( result[ 'group' ] ).toBe( '_all' )
 
         await rm( emptyCwd, { recursive: true, force: true } ).catch( () => {} )
     } )


### PR DESCRIPTION
Rollout of Memo 099 — removes self-imposed CLI friction. One global config, direct paths, all tools immediately callable, graceful missing-keys, no registry/internet sync.

## Commits
- `a56c63b` #71 — schemaFolders[] loader (direct paths, ~/anchor, _-dir skip)
- `485054c` #72 — no-activation call/list + graceful missing-keys (#resolveAllSchemas)
- `419b2c6` #73 — remove add/remove/reload/group/import/import-registry/update from router + help
- `0d0f766` #74 — [disabled: missing KEY] flag in list + search
- `742f570` #75 — README rewritten to the schemaFolders model

## Verification
- Full suite **84 suites / 868 tests green** (baseline 82/862; +2 new test suites).
- Live E2E vs real v4.0.0: list=1752 tools, key-gated tools flagged disabled, keyless call works without `add`, key-missing tool degrades gracefully ("N other tools remain callable"), removed commands return "Unknown command". Real ~/.flowmcp untouched during tests.

## Conformity (CONDITIONAL PASS — see .memo/099/rollout/conformity-report.md)
- 8/10 memo chapters fully implemented + tested.
- **Deferred by design** (tracked):
  - #76 (A1) — removed-command *methods* kept as dead code (commands gone from router/help); deletion cascades into ~24 fixture test files → separate hygiene issue.
  - #77 (D1) — config migration (PRD-007): loader auto-falls-back to legacy configs, and the memo strongly cautions No-Overwrite/No-Auto-Delete; documented manual 1-line switch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)