### PR TITLE
Memo 100: align addon registry keys to geo-*

### DIFF
--- a/src/data/addons.mjs
+++ b/src/data/addons.mjs
@@ -36,13 +36,20 @@ const ADDON_REGISTRY = {
         'defaultVersion': 'main',
         'urlMode': false
     },
-    'sqlite-geojson': {
+    'geo-geojson': {
+        // NOTE: `name` stays at the currently-installed/published package name
+        // until the GitHub repo is renamed + the add-on republished under
+        // `geo-geojson-toolkit` (user action, Memo 100 PRD-010 precondition).
+        // The loader imports by `name`, so it must match the installed module.
         'name': 'geojson-sqlite-toolkit',
         'source': 'github:FlowMCP/geojson-sqlite-toolkit',
         'defaultVersion': 'main',
         'urlMode': true
     },
-    'sqlite-csv': {
+    'geo-csv': {
+        // NOTE: `name` stays at the currently-installed/published package name
+        // until the GitHub repo is renamed + the add-on republished under
+        // `geo-csv-tsv-toolkit` (user action, Memo 100 PRD-010 precondition).
         'name': 'csv-tsv-sqlite-toolkit',
         'source': 'github:FlowMCP/csv-tsv-sqlite-toolkit',
         'defaultVersion': 'main',

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -5827,7 +5827,7 @@ class FlowMcpCli {
             } catch( err ) {
                 const result = FlowMcpCli.#error( {
                     'error': `RES044: failed to load url resource '${resource.url}' via ${addonName}: ${err.message}`,
-                    'fix': `Verify the url returns a complete, valid ${sourceKey === 'sqlite-csv' ? 'CSV/TSV (and parseConfig matches its columns)' : 'GeoJSON'} document over HTTPS.`
+                    'fix': `Verify the url returns a complete, valid ${sourceKey === 'geo-csv' ? 'CSV/TSV (and parseConfig matches its columns)' : 'GeoJSON'} document over HTTPS.`
                 } )
 
                 return { result }

--- a/src/validators/SqliteGtfsResourceValidator.mjs
+++ b/src/validators/SqliteGtfsResourceValidator.mjs
@@ -17,8 +17,8 @@ import { ADDON_REGISTRY } from '../data/addons.mjs'
  * SqliteGtfsResourceValidator
  *
  * Structural validation for any registered sqlite add-on resource
- * (`source` is a key in ADDON_REGISTRY, e.g. `sqlite-gtfs`, `sqlite-geojson`,
- * `sqlite-csv`). Emits RES030 (mode), RES031 (addon), and RES035 (path-variable).
+ * (`source` is a key in ADDON_REGISTRY, e.g. `sqlite-gtfs`, `geo-geojson`,
+ * `geo-csv`). Emits RES030 (mode), RES031 (addon), and RES035 (path-variable).
  *
  * Memo 051 REV-04 — Kap. 4.2 (RES030..RES035 codes), Kap. 7.1 (validate command),
  * Kap. 3.3 (Auto-Injection-Pfad Schritt 1 — Spec-Validator).
@@ -53,7 +53,7 @@ class SqliteGtfsResourceValidator {
 
                 const registryEntry = ADDON_REGISTRY[ source ]
 
-                // urlMode sources (sqlite-geojson, sqlite-csv) are URL-only (Memo 096 — F3=B,
+                // urlMode sources (geo-geojson, geo-csv) are URL-only (Memo 096 — F3=B,
                 // the converter/seal path was removed). File-based sources (sqlite-gtfs) reject url.
                 if( registryEntry.urlMode ) {
                     if( mode !== 'url' ) {
@@ -73,7 +73,7 @@ class SqliteGtfsResourceValidator {
                     errors.push( {
                         code: 'RES043',
                         severity: 'error',
-                        message: `mode 'url' is not supported by source '${source}'. Only sqlite-geojson and sqlite-csv support URL mode.`,
+                        message: `mode 'url' is not supported by source '${source}'. Only geo-geojson and geo-csv support URL mode.`,
                         path: `${basePath}.mode`
                     } )
                     return
@@ -100,14 +100,14 @@ class SqliteGtfsResourceValidator {
             } )
         }
 
-        // RES045 — sqlite-csv in url mode requires a parseConfig object (no silent default).
-        if( source === 'sqlite-csv' ) {
+        // RES045 — geo-csv in url mode requires a parseConfig object (no silent default).
+        if( source === 'geo-csv' ) {
             const parseConfigValid = parseConfig !== null && typeof parseConfig === 'object' && !Array.isArray( parseConfig )
             if( !parseConfigValid ) {
                 errors.push( {
                     code: 'RES045',
                     severity: 'error',
-                    message: `source 'sqlite-csv' with mode 'url' requires a 'parseConfig' object. No silent default.`,
+                    message: `source 'geo-csv' with mode 'url' requires a 'parseConfig' object. No silent default.`,
                     path: `${basePath}.parseConfig`
                 } )
             }

--- a/tests/integration/sqlite-addons-geojson-csv.test.mjs
+++ b/tests/integration/sqlite-addons-geojson-csv.test.mjs
@@ -92,8 +92,8 @@ const { FlowMcpCli } = await import( '../../src/task/FlowMcpCli.mjs' )
 
 
 const ADDONS = [
-    { sourceKey: 'sqlite-geojson', addonName: 'geojson-sqlite-toolkit', namespace: 'placesgeo', schemaName: 'places-geojson-v1', url: 'https://example.org/places.geojson', parseConfig: null },
-    { sourceKey: 'sqlite-csv', addonName: 'csv-tsv-sqlite-toolkit', namespace: 'placescsv', schemaName: 'places-csv-v1', url: 'https://example.org/places.csv', parseConfig: { delimiter: ',', header: true, latColumn: 'lat', lonColumn: 'lon' } }
+    { sourceKey: 'geo-geojson', addonName: 'geojson-sqlite-toolkit', namespace: 'placesgeo', schemaName: 'places-geojson-v1', url: 'https://example.org/places.geojson', parseConfig: null },
+    { sourceKey: 'geo-csv', addonName: 'csv-tsv-sqlite-toolkit', namespace: 'placescsv', schemaName: 'places-csv-v1', url: 'https://example.org/places.csv', parseConfig: { delimiter: ',', header: true, latColumn: 'lat', lonColumn: 'lon' } }
 ]
 
 

--- a/tests/unit/SqliteGtfsResourceValidator.test.mjs
+++ b/tests/unit/SqliteGtfsResourceValidator.test.mjs
@@ -138,13 +138,13 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
 // Memo 096 — geojson/csv add-on sources are URL-only (mode: 'url'). The
 // converter/file-based/seal path was removed (F3=B). gtfs stays file-based.
 describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', () => {
-    it( 'validates a fully-valid sqlite-geojson url resource without errors', () => {
+    it( 'validates a fully-valid geo-geojson url resource without errors', () => {
         const resources = [
             {
-                source: 'sqlite-geojson',
+                source: 'geo-geojson',
                 mode: 'url',
                 url: 'https://example.org/places.geojson',
-                addon: 'geojson-sqlite-toolkit'
+                addon: 'geo-geojson-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -153,13 +153,13 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
     } )
 
 
-    it( 'validates a fully-valid sqlite-csv url resource with parseConfig', () => {
+    it( 'validates a fully-valid geo-csv url resource with parseConfig', () => {
         const resources = [
             {
-                source: 'sqlite-csv',
+                source: 'geo-csv',
                 mode: 'url',
                 url: 'https://example.org/places.csv',
-                addon: 'csv-tsv-sqlite-toolkit',
+                addon: 'geo-csv-tsv-toolkit',
                 parseConfig: { delimiter: ',', header: true }
             }
         ]
@@ -169,30 +169,30 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
     } )
 
 
-    it( 'emits RES043 for a sqlite-geojson resource with file-based mode (converter path removed)', () => {
+    it( 'emits RES043 for a geo-geojson resource with file-based mode (converter path removed)', () => {
         const resources = [
             {
-                source: 'sqlite-geojson',
+                source: 'geo-geojson',
                 mode: 'file-based',
                 path: '${FLOWMCP_RESOURCES}/places.db',
-                addon: 'geojson-sqlite-toolkit'
+                addon: 'geo-geojson-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
 
         const res043 = errors.find( ( e ) => e.code === 'RES043' )
         expect( res043 ).toBeDefined()
-        expect( res043.message ).toContain( 'sqlite-geojson' )
+        expect( res043.message ).toContain( 'geo-geojson' )
     } )
 
 
-    it( 'emits RES044 for a sqlite-geojson url resource with a non-HTTPS url', () => {
+    it( 'emits RES044 for a geo-geojson url resource with a non-HTTPS url', () => {
         const resources = [
             {
-                source: 'sqlite-geojson',
+                source: 'geo-geojson',
                 mode: 'url',
                 url: 'http://example.org/places.geojson',
-                addon: 'geojson-sqlite-toolkit'
+                addon: 'geo-geojson-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -202,13 +202,13 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
     } )
 
 
-    it( 'emits RES045 for a sqlite-csv url resource missing parseConfig (no silent default)', () => {
+    it( 'emits RES045 for a geo-csv url resource missing parseConfig (no silent default)', () => {
         const resources = [
             {
-                source: 'sqlite-csv',
+                source: 'geo-csv',
                 mode: 'url',
                 url: 'https://example.org/places.csv',
-                addon: 'csv-tsv-sqlite-toolkit'
+                addon: 'geo-csv-tsv-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -218,10 +218,10 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
     } )
 
 
-    it( 'emits RES031 for a sqlite-csv url resource missing the addon field', () => {
+    it( 'emits RES031 for a geo-csv url resource missing the addon field', () => {
         const resources = [
             {
-                source: 'sqlite-csv',
+                source: 'geo-csv',
                 mode: 'url',
                 url: 'https://example.org/places.csv',
                 parseConfig: { delimiter: ',', header: true }
@@ -231,7 +231,7 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
 
         const res031 = errors.find( ( e ) => e.code === 'RES031' )
         expect( res031 ).toBeDefined()
-        expect( res031.message ).toContain( 'sqlite-csv' )
+        expect( res031.message ).toContain( 'geo-csv' )
     } )
 
 


### PR DESCRIPTION
PRD-010: addon registry keys sqlite-geojson→geo-geojson, sqlite-csv→geo-csv; validator+CLI refs updated. Registry name/dependency fields held at installed package names until add-ons republish under geo-*-toolkit (documented inline). 868 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)