### PR TITLE
Memo 100: geo-overpass-toolkit dependency + registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "figlet": "^1.10.0",
                 "flowmcp": "github:FlowMCP/flowmcp-core#de3a08888fa3945a284203d3c6ecd1419caab2bc",
                 "flowmcp-grading": "github:FlowMCP/flowmcp-grading#v2.1.0",
+                "geo-overpass-toolkit": "github:FlowMCP/geo-overpass-toolkit#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
                 "geojson-sqlite-toolkit": "github:FlowMCP/geojson-sqlite-toolkit#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
                 "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
                 "inquirer": "^12.3.0"
@@ -3667,6 +3668,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/geo-overpass-toolkit": {
+            "version": "0.1.0",
+            "resolved": "git+ssh://git@github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
+            "integrity": "sha512-pj8AmOMhveOWpUp24FCVdFVLISq1HBcE6MkW6nHoaKz8LZnQqasi37/gby0d1XGVCDTiQ7mvXeezKDP/pPs8JA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "node_modules/geojson-sqlite-toolkit": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "figlet": "^1.10.0",
         "flowmcp": "github:FlowMCP/flowmcp-core#de3a08888fa3945a284203d3c6ecd1419caab2bc",
         "flowmcp-grading": "github:FlowMCP/flowmcp-grading#v2.1.0",
+        "geo-overpass-toolkit": "github:FlowMCP/geo-overpass-toolkit#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
         "geojson-sqlite-toolkit": "github:FlowMCP/geojson-sqlite-toolkit#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
         "gtfs-sqlite-toolkit": "github:FlowMCP/gtfs-sqlite-toolkit#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
         "inquirer": "^12.3.0"

--- a/src/data/addons.mjs
+++ b/src/data/addons.mjs
@@ -54,6 +54,15 @@ const ADDON_REGISTRY = {
         'source': 'github:FlowMCP/csv-tsv-sqlite-toolkit',
         'defaultVersion': 'main',
         'urlMode': true
+    },
+    'geo-overpass': {
+        // Live-Query add-on (Memo 100). New repo, already named to the geo-*
+        // standard, so `name` matches the published package directly (no held
+        // legacy name). Live HTTP source — not url/file based, urlMode false.
+        'name': 'geo-overpass-toolkit',
+        'source': 'github:FlowMCP/geo-overpass-toolkit',
+        'defaultVersion': 'main',
+        'urlMode': false
     }
 }
 


### PR DESCRIPTION
Adds the geo-overpass-toolkit add-on to the CLI: package.json GitHub-pinned dependency (so requiredLibraries can inject it) + ADDON_REGISTRY `geo-overpass` entry. 868 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)