### PR TITLE
CI fix: package-lock git+ssh -> git+https for FlowMCP deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2965,7 +2965,7 @@
         },
         "node_modules/csv-tsv-sqlite-toolkit": {
             "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#b08b5288926b2620bf30b4d1b2571c574e1511bf",
+            "resolved": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#b08b5288926b2620bf30b4d1b2571c574e1511bf",
             "integrity": "sha512-hOjDNQlcRsrig+pIRbWAVIPePmtTF2SjBL4By3/T53ZBS34ZaH/mKGiF8jnEMv9en2M2o/x1r1y22TBBP0NQsw==",
             "license": "MIT",
             "engines": {
@@ -3532,7 +3532,7 @@
         "node_modules/flowmcp": {
             "name": "flowmcp-core",
             "version": "3.0.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
+            "resolved": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
             "integrity": "sha512-Ep6BIk/WhRpsscPVjPlQrN4MkzXyACf+dLEzN4F7z7dUNUTMjegnSTiJNh6Hwo1FuTrb6HemM2P9xH3a0OWTVQ==",
             "license": "MIT",
             "dependencies": {
@@ -3547,7 +3547,7 @@
         },
         "node_modules/flowmcp-grading": {
             "version": "2.1.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/flowmcp-grading.git#0348da41c33e604a5c6c2a4aa52b06d7827be008",
+            "resolved": "git+https://github.com/FlowMCP/flowmcp-grading.git#0348da41c33e604a5c6c2a4aa52b06d7827be008",
             "license": "MIT",
             "dependencies": {
                 "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
@@ -3560,7 +3560,7 @@
         "node_modules/flowmcp-grading/node_modules/flowmcp": {
             "name": "flowmcp-core",
             "version": "3.0.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/flowmcp-core.git#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+            "resolved": "git+https://github.com/FlowMCP/flowmcp-core.git#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
             "integrity": "sha512-+PUtEO/vwDN3WurjjfFDB1kF40qQ57JrFmr0Q+RvfIkzPT5gPl09VN5nXM5zvpW2gjtMZzH5+NNd1Odb+lf5nA==",
             "license": "MIT",
             "dependencies": {
@@ -3672,7 +3672,7 @@
         },
         "node_modules/geo-overpass-toolkit": {
             "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
+            "resolved": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
             "integrity": "sha512-pj8AmOMhveOWpUp24FCVdFVLISq1HBcE6MkW6nHoaKz8LZnQqasi37/gby0d1XGVCDTiQ7mvXeezKDP/pPs8JA==",
             "license": "MIT",
             "engines": {
@@ -3681,7 +3681,7 @@
         },
         "node_modules/geojson-sqlite-toolkit": {
             "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/geojson-sqlite-toolkit.git#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
+            "resolved": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
             "integrity": "sha512-RkR7hTcLF9Jr8dnJfZdb2/dSWSLtjQ5UznIt3mHFko8uFbEhjvEjSHlXd50zxGMZzeh7DZ6pvnNB8sXqrtjixQ==",
             "license": "MIT",
             "engines": {
@@ -3810,7 +3810,7 @@
         },
         "node_modules/gtfs-sqlite-toolkit": {
             "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/FlowMCP/gtfs-sqlite-toolkit.git#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
+            "resolved": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
             "integrity": "sha512-YdkOybEGJvCV/9smBEvMTWMIfX7nmZwsphiskjUrx/47n85A8ZrGLEa/FHf/RT4JgxrtDr2mBDmpouTy8v/Zmg==",
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
npm ci in CI has no SSH key; the ssh:// git-dep URLs fail with 'Permission denied (publickey)'. The new geo-overpass-toolkit entry forced a fresh fetch and surfaced it. Rewrites all FlowMCP git deps in package-lock to git+https (GitHub-Actions-token friendly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)