### PR TITLE
CI fix: rewrite git deps ssh->https before npm ci

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Fetch GitHub git deps over HTTPS (runner has no SSH key)
+        run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
The runner has no SSH key; npm resolves `github:` deps to `ssh://git@github.com` and the new geo-overpass-toolkit ls-remote fails with 'Permission denied (publickey)'. Adds a git `insteadOf` step rewriting ssh→https before `npm ci` — anonymous https works for all (public) FlowMCP deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)