### PR TITLE
Memo 100: repin add-ons to current main + geo-* names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
                 "@modelcontextprotocol/sdk": "^1.0.0",
                 "better-sqlite3": "^12.6.2",
                 "chalk": "^5.6.2",
-                "csv-tsv-sqlite-toolkit": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#b08b5288926b2620bf30b4d1b2571c574e1511bf",
                 "ethers": "^6.16.0",
                 "figlet": "^1.10.0",
                 "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
                 "flowmcp-grading": "git+https://github.com/FlowMCP/flowmcp-grading.git#v2.1.0",
+                "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
+                "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
+                "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
                 "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
-                "geojson-sqlite-toolkit": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
-                "gtfs-sqlite-toolkit": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
                 "inquirer": "^12.3.0"
             },
             "bin": {
@@ -40,13 +40,13 @@
             "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -55,9 +55,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -65,21 +65,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -96,14 +96,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -113,14 +113,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -130,9 +130,9 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -140,29 +140,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -172,9 +172,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -182,9 +182,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -192,9 +192,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -202,9 +202,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -212,27 +212,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -297,13 +297,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+            "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -339,13 +339,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-            "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+            "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -465,13 +465,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-            "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+            "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -481,33 +481,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -515,14 +515,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1633,16 +1633,22 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@noble/curves": {
@@ -1804,9 +1810,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.8.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+            "version": "25.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1845,9 +1851,9 @@
             "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+            "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
             "cpu": [
                 "arm"
             ],
@@ -1859,9 +1865,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+            "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1873,9 +1879,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+            "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
             "cpu": [
                 "arm64"
             ],
@@ -1887,9 +1893,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+            "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
             "cpu": [
                 "x64"
             ],
@@ -1901,9 +1907,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+            "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
             "cpu": [
                 "x64"
             ],
@@ -1915,9 +1921,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+            "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
             "cpu": [
                 "arm"
             ],
@@ -1929,9 +1935,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+            "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
             "cpu": [
                 "arm"
             ],
@@ -1943,9 +1949,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+            "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
             "cpu": [
                 "arm64"
             ],
@@ -1960,9 +1966,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+            "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
             "cpu": [
                 "arm64"
             ],
@@ -1976,10 +1982,44 @@
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+            "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+            "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+            "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1994,9 +2034,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+            "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
             "cpu": [
                 "riscv64"
             ],
@@ -2011,9 +2051,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+            "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
             "cpu": [
                 "riscv64"
             ],
@@ -2028,9 +2068,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+            "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
             "cpu": [
                 "s390x"
             ],
@@ -2045,9 +2085,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+            "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
             "cpu": [
                 "x64"
             ],
@@ -2062,9 +2102,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+            "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
             "cpu": [
                 "x64"
             ],
@@ -2078,10 +2118,24 @@
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+            "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+            "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
             "cpu": [
                 "wasm32"
             ],
@@ -2089,16 +2143,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.11"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+            "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
             "cpu": [
                 "arm64"
             ],
@@ -2110,9 +2166,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+            "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
             "cpu": [
                 "ia32"
             ],
@@ -2124,9 +2180,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+            "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
             "cpu": [
                 "x64"
             ],
@@ -2427,9 +2483,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.29",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+            "version": "2.10.32",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2498,9 +2554,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2650,9 +2706,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "dev": true,
             "funding": [
                 {
@@ -2963,18 +3019,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/csv-tsv-sqlite-toolkit": {
-            "version": "0.1.0",
-            "resolved": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#b08b5288926b2620bf30b4d1b2571c574e1511bf",
-            "integrity": "sha512-hOjDNQlcRsrig+pIRbWAVIPePmtTF2SjBL4By3/T53ZBS34ZaH/mKGiF8jnEMv9en2M2o/x1r1y22TBBP0NQsw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "better-sqlite3": "^11.10.0 || ^12.0.0"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3097,9 +3141,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.356",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-            "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+            "version": "1.5.363",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
+            "integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
             "dev": true,
             "license": "ISC"
         },
@@ -3170,9 +3214,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -3266,12 +3310,6 @@
                 "undici-types": "~6.19.2"
             }
         },
-        "node_modules/ethers/node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-            "license": "0BSD"
-        },
         "node_modules/ethers/node_modules/undici-types": {
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -3291,9 +3329,9 @@
             }
         },
         "node_modules/eventsource-parser": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-            "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+            "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -3550,7 +3588,7 @@
             "resolved": "git+https://github.com/FlowMCP/flowmcp-grading.git#0348da41c33e604a5c6c2a4aa52b06d7827be008",
             "license": "MIT",
             "dependencies": {
-                "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
+                "flowmcp": "github:FlowMCP/flowmcp-core#bca23b1fb8727fb4cd4877b1c0ea94f4ac14acb5",
                 "js-yaml": "^3.14.2"
             },
             "engines": {
@@ -3670,6 +3708,40 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/geo-csv-tsv-toolkit": {
+            "version": "2.0.0",
+            "resolved": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
+            "integrity": "sha512-YI2LptTXApGHT34uyUDrCj1SZx5Kyt0Aw9Y6zSmH8aF6C0/QBc9Enva2KcmTKFDREKmXs6m/qBnZ/H/rdbUZBg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/geo-geojson-toolkit": {
+            "version": "2.0.0",
+            "resolved": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
+            "integrity": "sha512-W+KGOy7MC+e8mNSbGr+Im+kIf3fOSdQVK8kxoNbGYpLuBqktVa/uLmO+NNjruoWTpYi/A8M53Tqmss4UP9nnaw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/geo-gtfs-toolkit": {
+            "version": "0.2.0",
+            "resolved": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
+            "integrity": "sha512-G7Z8Vh2v1RHICdTtL3I63Rf93mkoxjXJ7jU1BRRGCAjR2VL50ZPiub1gWP/1CYSY2NCcT9Qb+FQj3cFNslofnA==",
+            "license": "MIT",
+            "dependencies": {
+                "tar": "^7.4.3",
+                "yauzl": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            },
+            "peerDependencies": {
+                "better-sqlite3": "^11.10.0 || ^12.0.0"
+            }
+        },
         "node_modules/geo-overpass-toolkit": {
             "version": "0.1.0",
             "resolved": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
@@ -3677,18 +3749,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "node_modules/geojson-sqlite-toolkit": {
-            "version": "0.1.0",
-            "resolved": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
-            "integrity": "sha512-RkR7hTcLF9Jr8dnJfZdb2/dSWSLtjQ5UznIt3mHFko8uFbEhjvEjSHlXd50zxGMZzeh7DZ6pvnNB8sXqrtjixQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "better-sqlite3": "^11.10.0 || ^12.0.0"
             }
         },
         "node_modules/get-caller-file": {
@@ -3808,22 +3868,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/gtfs-sqlite-toolkit": {
-            "version": "0.1.0",
-            "resolved": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
-            "integrity": "sha512-YdkOybEGJvCV/9smBEvMTWMIfX7nmZwsphiskjUrx/47n85A8ZrGLEa/FHf/RT4JgxrtDr2mBDmpouTy8v/Zmg==",
-            "license": "MIT",
-            "dependencies": {
-                "tar": "^7.4.3",
-                "yauzl": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "better-sqlite3": "^11.10.0 || ^12.0.0"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3859,9 +3903,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.18",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-            "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+            "version": "4.12.23",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+            "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -4117,9 +4161,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5031,9 +5075,9 @@
             }
         },
         "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5375,9 +5419,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5599,9 +5643,9 @@
             }
         },
         "node_modules/node-abi/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -5618,11 +5662,14 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.44",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -6000,9 +6047,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -6751,9 +6798,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6813,9 +6860,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
             "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
@@ -6901,38 +6948,41 @@
             }
         },
         "node_modules/unrs-resolver": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+            "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "napi-postinstall": "^0.3.0"
+                "napi-postinstall": "^0.3.4"
             },
             "funding": {
                 "url": "https://opencollective.com/unrs-resolver"
             },
             "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-                "@unrs/resolver-binding-android-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-x64": "1.11.1",
-                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+                "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+                "@unrs/resolver-binding-android-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-x64": "1.12.2",
+                "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+                "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+                "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -7304,9 +7354,9 @@
             }
         },
         "node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+            "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
             "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
         "chalk": "^5.6.2",
-        "csv-tsv-sqlite-toolkit": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#b08b5288926b2620bf30b4d1b2571c574e1511bf",
         "ethers": "^6.16.0",
         "figlet": "^1.10.0",
         "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
         "flowmcp-grading": "git+https://github.com/FlowMCP/flowmcp-grading.git#v2.1.0",
+        "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/csv-tsv-sqlite-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
+        "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
+        "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
         "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
-        "geojson-sqlite-toolkit": "git+https://github.com/FlowMCP/geojson-sqlite-toolkit.git#adeb4c779161759a39f5617ee2450c6e7dd2f98b",
-        "gtfs-sqlite-toolkit": "git+https://github.com/FlowMCP/gtfs-sqlite-toolkit.git#9a37238e3a5cc11fb53bce90e702b59cb3d24739",
         "inquirer": "^12.3.0"
     },
     "devDependencies": {

--- a/src/data/addons.mjs
+++ b/src/data/addons.mjs
@@ -31,26 +31,21 @@
  */
 const ADDON_REGISTRY = {
     'sqlite-gtfs': {
-        'name': 'gtfs-sqlite-toolkit',
+        // `name` = the package's own name (geo-gtfs-toolkit); the loader imports
+        // by `name`. The GitHub repo keeps its original name (not renamed).
+        'name': 'geo-gtfs-toolkit',
         'source': 'github:FlowMCP/gtfs-sqlite-toolkit',
         'defaultVersion': 'main',
         'urlMode': false
     },
     'geo-geojson': {
-        // NOTE: `name` stays at the currently-installed/published package name
-        // until the GitHub repo is renamed + the add-on republished under
-        // `geo-geojson-toolkit` (user action, Memo 100 PRD-010 precondition).
-        // The loader imports by `name`, so it must match the installed module.
-        'name': 'geojson-sqlite-toolkit',
+        'name': 'geo-geojson-toolkit',
         'source': 'github:FlowMCP/geojson-sqlite-toolkit',
         'defaultVersion': 'main',
         'urlMode': true
     },
     'geo-csv': {
-        // NOTE: `name` stays at the currently-installed/published package name
-        // until the GitHub repo is renamed + the add-on republished under
-        // `geo-csv-tsv-toolkit` (user action, Memo 100 PRD-010 precondition).
-        'name': 'csv-tsv-sqlite-toolkit',
+        'name': 'geo-csv-tsv-toolkit',
         'source': 'github:FlowMCP/csv-tsv-sqlite-toolkit',
         'defaultVersion': 'main',
         'urlMode': true

--- a/tests/integration/cli-add-sqlite-gtfs.test.mjs
+++ b/tests/integration/cli-add-sqlite-gtfs.test.mjs
@@ -16,7 +16,7 @@ const REPO_ROOT = dirname( dirname( dirname( fileURLToPath( import.meta.url ) ) 
 const FIXTURE_DIR = join(
     REPO_ROOT,
     'node_modules',
-    'gtfs-sqlite-toolkit',
+    'geo-gtfs-toolkit',
     'tests',
     'fixtures',
     'synthetic-gtfs'
@@ -90,7 +90,7 @@ beforeAll( async () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${FLOWMCP_RESOURCES}/gtfs-de.db',
-            addon: 'gtfs-sqlite-toolkit',
+            addon: 'geo-gtfs-toolkit',
             addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
         }
     ]
@@ -128,7 +128,7 @@ describe( 'flowmcp add — sqlite-gtfs POC against synthetic fixture (PRD-26)', 
         expect( addResult.result ).toBeDefined()
         expect( addResult.result.status ).toBe( true )
         expect( addResult.result.namespace ).toBe( 'gtfsde' )
-        expect( addResult.result.addon ).toBe( 'gtfs-sqlite-toolkit' )
+        expect( addResult.result.addon ).toBe( 'geo-gtfs-toolkit' )
         expect( addResult.result.sourceKey ).toBe( 'sqlite-gtfs' )
     } )
 

--- a/tests/integration/cli-call-sqlite-gtfs.test.mjs
+++ b/tests/integration/cli-call-sqlite-gtfs.test.mjs
@@ -15,7 +15,7 @@ const REPO_ROOT = dirname( dirname( dirname( fileURLToPath( import.meta.url ) ) 
 const FIXTURE_DIR = join(
     REPO_ROOT,
     'node_modules',
-    'gtfs-sqlite-toolkit',
+    'geo-gtfs-toolkit',
     'tests',
     'fixtures',
     'synthetic-gtfs'
@@ -83,7 +83,7 @@ beforeAll( async () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${FLOWMCP_RESOURCES}/gtfs-de.db',
-            addon: 'gtfs-sqlite-toolkit',
+            addon: 'geo-gtfs-toolkit',
             addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
         }
     ]

--- a/tests/integration/cli-error-res032.test.mjs
+++ b/tests/integration/cli-error-res032.test.mjs
@@ -75,7 +75,7 @@ beforeAll( async () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${FLOWMCP_RESOURCES}/gtfs-de.db',
-            addon: 'gtfs-sqlite-toolkit',
+            addon: 'geo-gtfs-toolkit',
             addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
         }
     ]

--- a/tests/integration/cli-error-res035.test.mjs
+++ b/tests/integration/cli-error-res035.test.mjs
@@ -57,7 +57,7 @@ beforeAll( async () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${${BROKEN_VAR}}/foo.db',
-            addon: 'gtfs-sqlite-toolkit',
+            addon: 'geo-gtfs-toolkit',
             addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
         }
     ]

--- a/tests/integration/fixtures/gtfsde-transit-v2.mjs
+++ b/tests/integration/fixtures/gtfsde-transit-v2.mjs
@@ -20,7 +20,7 @@ export const schema = {
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_RESOURCES}/gtfs-de.db',
-                addon: 'gtfs-sqlite-toolkit',
+                addon: 'geo-gtfs-toolkit',
                 addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
             }
         ]

--- a/tests/integration/spec-validator-sqlite-gtfs.test.mjs
+++ b/tests/integration/spec-validator-sqlite-gtfs.test.mjs
@@ -16,7 +16,7 @@ const REPO_ROOT = dirname( dirname( dirname( fileURLToPath( import.meta.url ) ) 
 const FIXTURE_DIR = join(
     REPO_ROOT,
     'node_modules',
-    'gtfs-sqlite-toolkit',
+    'geo-gtfs-toolkit',
     'tests',
     'fixtures',
     'synthetic-gtfs'
@@ -83,7 +83,7 @@ describe( 'SqliteGtfsResourceValidator — RES030 (mode must be file-based)', ()
                 source: 'sqlite-gtfs',
                 mode: 'in-memory',
                 path: '${FLOWMCP_RESOURCES}/synthetic-gtfs.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
 
@@ -119,7 +119,7 @@ describe( 'SqliteGtfsResourceValidator — RES031 (addon field required)', () =>
 
 describe( 'SqliteGtfsResourceValidator — RES032 (DB without seal)', () => {
     it( 'a plain SQLite DB without qualitySeal is detected as unsealed (NO_SEAL)', async () => {
-        const { FlowMcpAdapter } = await import( 'gtfs-sqlite-toolkit' )
+        const { FlowMcpAdapter } = await import( 'geo-gtfs-toolkit' )
 
         const verifyResult = FlowMcpAdapter.verifySeal( { dbPath: NO_SEAL_DB } )
 
@@ -131,7 +131,7 @@ describe( 'SqliteGtfsResourceValidator — RES032 (DB without seal)', () => {
 
 describe( 'SqliteGtfsResourceValidator — RES033 (DB cannot be opened)', () => {
     it( 'a path pointing to a nonexistent file is reported by the adapter as DB_UNREADABLE', async () => {
-        const { FlowMcpAdapter } = await import( 'gtfs-sqlite-toolkit' )
+        const { FlowMcpAdapter } = await import( 'geo-gtfs-toolkit' )
 
         const verifyResult = FlowMcpAdapter.verifySeal( {
             dbPath: join( FIXTURE_DIR, 'does-not-exist-dir', 'missing.db' )
@@ -150,7 +150,7 @@ describe( 'SqliteGtfsResourceValidator — RES034 (spec revision drift)', () => 
         // NOT perform any disk I/O. This test documents the contract: the synthetic
         // fixture exposes a specRevision via meta, and any pipeline drift check
         // must compare against this value, not classify it as an error.
-        const { FlowMcpAdapter } = await import( 'gtfs-sqlite-toolkit' )
+        const { FlowMcpAdapter } = await import( 'geo-gtfs-toolkit' )
 
         const verifyResult = FlowMcpAdapter.verifySeal( { dbPath: FIXTURE_DB } )
 
@@ -170,7 +170,7 @@ describe( 'SqliteGtfsResourceValidator — RES035 (path variable unknown)', () =
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_UNKNOWN_VAR}/foo.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
 
@@ -191,7 +191,7 @@ describe( 'SqliteGtfsResourceValidator — RES035 (path variable unknown)', () =
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_UNKNOWN_VAR}/foo.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
 
@@ -211,7 +211,7 @@ describe( 'SqliteGtfsResourceValidator — positive case (synthetic fixture sche
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_RESOURCES}/synthetic-gtfs.db',
-                addon: 'gtfs-sqlite-toolkit',
+                addon: 'geo-gtfs-toolkit',
                 addonSource: 'github:FlowMCP/gtfs-sqlite-toolkit'
             }
         ]

--- a/tests/integration/sqlite-addons-geojson-csv.test.mjs
+++ b/tests/integration/sqlite-addons-geojson-csv.test.mjs
@@ -84,16 +84,16 @@ function buildFakeAdapter() {
 }
 
 
-jest.unstable_mockModule( 'geojson-sqlite-toolkit', () => buildFakeAdapter() )
-jest.unstable_mockModule( 'csv-tsv-sqlite-toolkit', () => buildFakeAdapter() )
+jest.unstable_mockModule( 'geo-geojson-toolkit', () => buildFakeAdapter() )
+jest.unstable_mockModule( 'geo-csv-tsv-toolkit', () => buildFakeAdapter() )
 
 // FlowMcpCli must be imported AFTER the mocks + createTestHome side-effects.
 const { FlowMcpCli } = await import( '../../src/task/FlowMcpCli.mjs' )
 
 
 const ADDONS = [
-    { sourceKey: 'geo-geojson', addonName: 'geojson-sqlite-toolkit', namespace: 'placesgeo', schemaName: 'places-geojson-v1', url: 'https://example.org/places.geojson', parseConfig: null },
-    { sourceKey: 'geo-csv', addonName: 'csv-tsv-sqlite-toolkit', namespace: 'placescsv', schemaName: 'places-csv-v1', url: 'https://example.org/places.csv', parseConfig: { delimiter: ',', header: true, latColumn: 'lat', lonColumn: 'lon' } }
+    { sourceKey: 'geo-geojson', addonName: 'geo-geojson-toolkit', namespace: 'placesgeo', schemaName: 'places-geojson-v1', url: 'https://example.org/places.geojson', parseConfig: null },
+    { sourceKey: 'geo-csv', addonName: 'geo-csv-tsv-toolkit', namespace: 'placescsv', schemaName: 'places-csv-v1', url: 'https://example.org/places.csv', parseConfig: { delimiter: ',', header: true, latColumn: 'lat', lonColumn: 'lon' } }
 ]
 
 

--- a/tests/integration/sqlite-gtfs-pipeline.test.mjs
+++ b/tests/integration/sqlite-gtfs-pipeline.test.mjs
@@ -10,7 +10,7 @@ import { createTestHome } from '../helpers/test-home.mjs'
 const REPO_ROOT = dirname( dirname( dirname( fileURLToPath( import.meta.url ) ) ) )
 const TOOLKIT_FIXTURE_DB = join(
     dirname( REPO_ROOT ),
-    'gtfs-sqlite-toolkit',
+    'geo-gtfs-toolkit',
     'tests',
     'fixtures',
     'synthetic-gtfs',
@@ -70,7 +70,7 @@ beforeEach( async () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${FLOWMCP_RESOURCES}/gtfs-de.db',
-            addon: 'gtfs-sqlite-toolkit'
+            addon: 'geo-gtfs-toolkit'
         }
     ]
 }
@@ -85,7 +85,7 @@ beforeEach( async () => {
         {
             source: 'sqlite-gtfs',
             mode: 'in-memory',
-            addon: 'gtfs-sqlite-toolkit'
+            addon: 'geo-gtfs-toolkit'
         }
     ]
 }
@@ -112,7 +112,7 @@ describe( 'flowmcp add sqlite-gtfs schema (PRD-18)', () => {
         if( fixtureExists ) {
             expect( result.status ).toBe( true )
             expect( result.namespace ).toBe( 'gtfsde' )
-            expect( result.addon ).toBe( 'gtfs-sqlite-toolkit' )
+            expect( result.addon ).toBe( 'geo-gtfs-toolkit' )
             expect( result.sourceKey ).toBe( 'sqlite-gtfs' )
             expect( Array.isArray( result.tools ) ).toBe( true )
             expect( result.tools.length ).toBeGreaterThan( 0 )
@@ -225,7 +225,7 @@ describe( 'flowmcp add sqlite-gtfs — override behavior (PRD-22)', () => {
             source: 'sqlite-gtfs',
             mode: 'file-based',
             path: '\${FLOWMCP_RESOURCES}/gtfs-de.db',
-            addon: 'gtfs-sqlite-toolkit'
+            addon: 'geo-gtfs-toolkit'
         }
     ],
     tools: {

--- a/tests/unit/SqliteGtfsResourceValidator.test.mjs
+++ b/tests/unit/SqliteGtfsResourceValidator.test.mjs
@@ -27,7 +27,7 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_RESOURCES}/gtfs-de.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -41,7 +41,7 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
             {
                 source: 'sqlite-gtfs',
                 mode: 'in-memory',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -72,7 +72,7 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_XYZ}/foo.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -88,7 +88,7 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
                 source: 'sqlite-gtfs',
                 mode: 'file-based',
                 path: '${FLOWMCP_RESOURCES}/foo.db',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
@@ -113,7 +113,7 @@ describe( 'SqliteGtfsResourceValidator.validateResources', () => {
     it( 'reports error path index for arrays', () => {
         const resources = [
             { source: 'sqlite', mode: 'in-memory' },
-            { source: 'sqlite-gtfs', mode: 'in-memory', addon: 'gtfs-sqlite-toolkit' }
+            { source: 'sqlite-gtfs', mode: 'in-memory', addon: 'geo-gtfs-toolkit' }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )
 
@@ -241,7 +241,7 @@ describe( 'SqliteGtfsResourceValidator — URL-mode add-on sources (Memo 096)', 
                 source: 'sqlite-gtfs',
                 mode: 'url',
                 url: 'https://example.org/feed.zip',
-                addon: 'gtfs-sqlite-toolkit'
+                addon: 'geo-gtfs-toolkit'
             }
         ]
         const { errors } = SqliteGtfsResourceValidator.validateResources( { resources } )

--- a/tests/unit/loadAddon.test.mjs
+++ b/tests/unit/loadAddon.test.mjs
@@ -7,7 +7,7 @@ describe( 'AddonLoader.loadAddon', () => {
     it( 'loads gtfs-sqlite-toolkit for sourceKey sqlite-gtfs', async () => {
         const result = await AddonLoader.loadAddon( { sourceKey: 'sqlite-gtfs' } )
 
-        expect( result.addonName ).toBe( 'gtfs-sqlite-toolkit' )
+        expect( result.addonName ).toBe( 'geo-gtfs-toolkit' )
         expect( [ 'live', 'local' ] ).toContain( result.source )
         expect( typeof result.addonModule.FlowMcpAdapter ).toBe( 'function' )
     } )


### PR DESCRIPTION
Bumps geojson/csv/gtfs add-on pins to their post-alignment main commits, so the CLI now exposes the new APIs (FeatureCollection output, geojson URL in-memory mode, gtfs spatial nearPoint/inBoundingBox). Dependency keys + ADDON_REGISTRY names flipped to geo-geojson-toolkit / geo-csv-tsv-toolkit / geo-gtfs-toolkit (the loader imports by name = the installed package name); GitHub repo URLs unchanged. Test mocks/specifiers updated. 868 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)