### PR TITLE
Pin flowmcp-grading by commit hash (consistency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "ethers": "^6.16.0",
                 "figlet": "^1.10.0",
                 "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
-                "flowmcp-grading": "github:FlowMCP/flowmcp-grading#v2.4.0",
+                "flowmcp-grading": "github:FlowMCP/flowmcp-grading#f8bededa2328e09198930367046ca9e4885f4744",
                 "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/geo-csv-tsv-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
                 "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
                 "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "ethers": "^6.16.0",
         "figlet": "^1.10.0",
         "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
-        "flowmcp-grading": "github:FlowMCP/flowmcp-grading#v2.4.0",
+        "flowmcp-grading": "github:FlowMCP/flowmcp-grading#f8bededa2328e09198930367046ca9e4885f4744",
         "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/geo-csv-tsv-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
         "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
         "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",


### PR DESCRIPTION
Closes #100. Follow-up to #99.

Switches the `flowmcp-grading` pin from the `#v2.4.0` tag to the commit hash it resolves to (`f8bededa2328e09198930367046ca9e4885f4744`), matching the hash-pinned sibling deps (`flowmcp-core`, `geo-*-toolkit`) and removing tag-mutability risk.

- **No code/behaviour change** — identical commit, grading stays 2.4.0.
- `package-lock.json` resolved SHA was already `f8beded`; this only aligns the package.json spec + the lock's spec mirror so `npm ci` stays in sync.
- Verified locally: `npm ci` clean, grading suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)