### PR TITLE
Fix: --on-conflict=overwrite never overwrites (#writeAtomic)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowmcp-cli",
-    "version": "4.5.0",
+    "version": "4.5.1",
     "description": "CLI for developing and validating FlowMCP schemas",
     "type": "module",
     "license": "MIT",

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -14884,11 +14884,23 @@ allowlist, migrate-config, etc.).
 
     static async #writeAtomic( { path, content, onConflict } ) {
         const absolutePath = resolve( path )
+        // NO SILENT DEFAULT: the conflict policy must be one of the three known
+        // values. An unknown value is a hard error, never a silent fall-through.
+        const validConflicts = [ 'abort', 'skip', 'overwrite' ]
+        if( validConflicts.includes( onConflict ) === false ) {
+            throw new Error( `#writeAtomic: invalid onConflict '${onConflict}' (expected one of ${validConflicts.join( ', ' )})` )
+        }
         if( existsSync( absolutePath ) ) {
             if( onConflict === 'abort' ) {
                 throw new Error( `NO-OVERWRITE conflict: ${absolutePath} already exists` )
             }
-            return { 'skipped': true, absolutePath }
+            // 'skip' keeps the existing file; 'overwrite' falls through to the atomic
+            // write below (the tmp+rename replaces the existing file). The previous
+            // code returned skipped for BOTH, so --on-conflict=overwrite never
+            // overwrote — a stale prompts.json was kept indefinitely.
+            if( onConflict === 'skip' ) {
+                return { 'skipped': true, absolutePath }
+            }
         }
         const tmp = `${absolutePath}.tmp`
         await writeFile( tmp, content, 'utf-8' )

--- a/tests/unit/grading-phase2-areas.test.mjs
+++ b/tests/unit/grading-phase2-areas.test.mjs
@@ -445,3 +445,44 @@ describe( 'Memo 110 P3 — Emit-Skill text (PRD-3.3/3.4) + maxTurns (PRD-3.5)', 
         expect( result.error ).toContain( 'Invalid --max-turns' )
     } )
 } )
+
+
+// ---- writeAtomic overwrite fix: --on-conflict=overwrite must actually rewrite ----
+describe( 'emit --on-conflict — skip keeps, overwrite rewrites (writeAtomic fix)', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    async function emitConflict( { cwd, onConflict } ) {
+        return FlowMcpCli.gradingRun( {
+            cwd, gradingDataDir: '.flowmcp/grading', target: 'demoapi',
+            phase: null, emitPrompts: true, consumeScores: null, onConflict,
+            maxIterations: null, json: false
+        } )
+    }
+
+    it( 'default (skip) keeps the existing prompts.json on a second emit', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        await emitConflict( { cwd, onConflict: null } )
+        const { result } = await emitConflict( { cwd, onConflict: 'skip' } )
+        expect( result.skipped ).toBe( true )
+    } )
+
+    it( 'overwrite rewrites the prompts.json (skipped:false) instead of keeping a stale one', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        const first = await emitConflict( { cwd, onConflict: null } )
+        const promptsPath = join( cwd, '.flowmcp/grading/providers/demoapi/prompts.json' )
+
+        // Corrupt the on-disk file to a sentinel, then overwrite-emit must replace it.
+        await writeFile( promptsPath, JSON.stringify( { sentinel: 'STALE' } ), 'utf-8' )
+        const { result } = await emitConflict( { cwd, onConflict: 'overwrite' } )
+        expect( result.skipped ).toBe( false )
+
+        const rewritten = JSON.parse( await readFile( promptsPath, 'utf-8' ) )
+        expect( rewritten.sentinel ).toBeUndefined()
+        expect( rewritten.taskId ).toBe( first.result.taskId )
+        // the rewritten artifact carries the filled emit-skill (Memo 110)
+        expect( typeof rewritten.emitSkill ).toBe( 'string' )
+        expect( rewritten.emitSkill.includes( '{{TOOL_NAME}}' ) ).toBe( false )
+    } )
+} )


### PR DESCRIPTION
Closes #102.

`#writeAtomic` returned `skipped:true` for **every** existing-file case except `abort` — so `--on-conflict=overwrite` was a silent no-op. A stale `prompts.json` (e.g. an old emit carrying the pre-Memo-110 torso) was kept indefinitely and could never be regenerated in place.

**Fix:** `overwrite` falls through to the atomic tmp+rename write; `skip` still keeps the existing file; an unknown `onConflict` is now a hard error (no silent default).

**Tests:** jest regression (skip keeps / overwrite rewrites + filled emit-skill, no torso) + verified end-to-end with the real CLI:
`flowmcp grading non-deterministic etherscan --emit-prompts --on-conflict=overwrite` → `skipped:false`, island prompts.json rewritten with the 10.8k-char filled emit-skill (`grading/3.0.0`, no `{{…}}`).

Patch bump 4.5.0 → 4.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)