### PR TITLE
Add 'flowmcp grading skill <ns>' to print the emit-skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowmcp-cli",
-    "version": "4.5.1",
+    "version": "4.6.0",
     "description": "CLI for developing and validating FlowMCP schemas",
     "type": "module",
     "license": "MIT",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -517,7 +517,16 @@ const runCommand = async () => {
             // code drift). The mode (--emit-prompts | --consume-scores) is still
             // explicit — no silent default.
             const { result } = await FlowMcpCli.gradingRun( { cwd, target, phase, emitPrompts, consumeScores, onConflict, memberSource, gradingDataDir, gradingExportDir, maxIterations, maxTurns, withKeys, dryRun, quiet, json } )
-            output( { result } )
+            // The planned round-trip: `--emit-prompts` (without --json) RETURNS the
+            // self-contained Emit-Skill TEXT directly — the thing you hand to a
+            // subagent — so no jq/field-digging is needed. The machine envelope stays
+            // available via --json (the harness already passes it). --consume-scores
+            // and every error keep the JSON envelope so failures stay machine-readable.
+            if( emitPrompts === true && json !== true && result.status === true && typeof result.emitSkill === 'string' ) {
+                process.stdout.write( result.emitSkill + '\n' )
+            } else {
+                output( { result } )
+            }
 
             return true
         }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -433,13 +433,13 @@ const runCommand = async () => {
         // non-deterministic LLM-scoring path (emit + consume), formerly only reached
         // via `run --emit-prompts` / `run --consume-scores`. `run` is kept as the
         // internal mechanic (Never-delete-legacy).
-        const validSubCommands = [ 'deterministic', 'non-deterministic', 'reload', 'export', 'run', 'state', 'worklist', 'doctor', 'config' ]
+        const validSubCommands = [ 'deterministic', 'non-deterministic', 'reload', 'skill', 'export', 'run', 'state', 'worklist', 'doctor', 'config' ]
 
         if( !subCommand || !validSubCommands.includes( subCommand ) ) {
             const result = {
                 'status': false,
                 'error': 'Missing or unknown grading sub-command.',
-                'fix': `Use: ${appConfig[ 'cliCommand' ]} grading deterministic <id> [--force] | non-deterministic <ns|selection> --emit-prompts | --consume-scores <path> | reload <ns|ns/schema> | export <ns|selection> | state <ns|selection> | worklist <ns> | doctor <ns> | config [--set-data-dir <path>] [--set-export-dir <path>]`
+                'fix': `Use: ${appConfig[ 'cliCommand' ]} grading deterministic <id> [--force] | non-deterministic <ns|selection> --emit-prompts | --consume-scores <path> | reload <ns|ns/schema> | skill <ns|selection> | export <ns|selection> | state <ns|selection> | worklist <ns> | doctor <ns> | config [--set-data-dir <path>] [--set-export-dir <path>]`
             }
             output( { result } )
 
@@ -485,6 +485,20 @@ const runCommand = async () => {
             // decoupled from grading: no _gradings/grade.json writes.
             const { result } = await FlowMcpCli.gradingReload( { cwd, target, gradingDataDir, withKeys, quiet, json } )
             output( { result } )
+
+            return true
+        }
+
+        if( subCommand === 'skill' ) {
+            // Print the emitted Emit-Skill TEXT directly. Default: raw text to stdout
+            // (pipe/redirect ready). --json: the structured envelope. An error always
+            // prints the JSON envelope so failures stay machine-readable.
+            const { result } = await FlowMcpCli.gradingSkill( { cwd, target, gradingDataDir } )
+            if( result.status === true && json !== true ) {
+                process.stdout.write( result.skill + '\n' )
+            } else {
+                output( { result } )
+            }
 
             return true
         }

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -14390,6 +14390,51 @@ allowlist, migrate-config, etc.).
     // Memo 097 Kap. 3 (PA-3) — flat, deduplicated error/improvement worklist for
     // one namespace. A sub-agent abarbeitet this list directly. Sources merged:
     //   - prompts.json -> pretests[].errors  (DPT-003 abort, DPT-004 test-fail /
+    // `grading skill <ns|selection>` — print the emitted Emit-Skill TEXT (read-only).
+    // The non-deterministic emit writes the self-contained skill into the island
+    // prompts.json (field `emitSkill`); this command reads it back and returns the
+    // raw text so the operator never has to dig the field out of the machine JSON by
+    // hand. NO SILENT DEFAULT: a missing prompts.json (never emitted) or a stale
+    // artifact without an `emitSkill` field is a clear coded error, not empty output.
+    static async gradingSkill( { cwd, target, gradingDataDir } ) {
+        const grading = await FlowMcpCli.#loadGradingModule()
+        if( grading === null ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'grading module unavailable', 'fix': 'npm install / update the flowmcp-grading dependency' } ) }
+        }
+        if( typeof target !== 'string' || target.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': 'Missing skill target.', 'fix': 'Usage: flowmcp grading skill <namespace|selection>' } ) }
+        }
+
+        const gradingDataRoot = await FlowMcpCli.#gradingDataRoot( { cwd, gradingDataDir } )
+        const detected = await FlowMcpCli.#resolveGradingTarget( { cwd, gradingDataRoot, target } )
+        if( detected.status !== true ) {
+            return { 'result': FlowMcpCli.#error( { 'error': detected.error, 'fix': detected.fix } ) }
+        }
+
+        const promptsPath = join( detected.targetDir, 'prompts.json' )
+        const { data: prompts } = await FlowMcpCli.#readJson( { 'filePath': promptsPath } )
+        if( prompts === null ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `No emitted skill found for "${target}" (no prompts.json in the island).`, 'fix': `Emit it first: ${appConfig[ 'cliCommand' ]} grading non-deterministic ${target} --emit-prompts` } ) }
+        }
+
+        const skill = prompts[ 'emitSkill' ]
+        if( typeof skill !== 'string' || skill.length === 0 ) {
+            return { 'result': FlowMcpCli.#error( { 'error': `The emitted prompts.json for "${target}" carries no emit-skill (stale artifact from before the self-contained Emit-Skill).`, 'fix': `Re-emit to refresh it: ${appConfig[ 'cliCommand' ]} grading non-deterministic ${target} --emit-prompts --on-conflict=overwrite` } ) }
+        }
+
+        return {
+            'result': {
+                'status': true,
+                target,
+                'taskId': prompts[ 'taskId' ] === undefined ? null : prompts[ 'taskId' ],
+                'emittedAreaSet': prompts[ 'emittedAreaSet' ] === undefined ? null : prompts[ 'emittedAreaSet' ],
+                'promptsPath': FlowMcpCli.#toRepoRelativePath( { cwd, 'path': promptsPath } ),
+                skill
+            }
+        }
+    }
+
+
     //     not-downloadable, DPT-005 missing requiredServerParam — KEY NAME only,
     //     never the value; the emit stage already strips values)
     //   - index.json   -> blockers[]         (import / rebuild errors: {node,reason})

--- a/src/task/FlowMcpCli.mjs
+++ b/src/task/FlowMcpCli.mjs
@@ -13538,7 +13538,12 @@ allowlist, migrate-config, etc.).
             return { 'result': FlowMcpCli.#error( { 'error': `NO-OVERWRITE conflict: ${promptsPath} already exists`, 'fix': 'Pass --on-conflict=skip to keep the existing handoff, or remove it deliberately.' } ) }
         }
         if( dryRun !== true && existsSync( promptsPath ) === true && conflict === 'skip' ) {
-            return { 'result': { 'status': true, 'stage': 1, 'mode': 'emit-prompts', 'skipped': true, promptsPath, statePath, dependencyChain } }
+            // Skip the (slow) re-emit but still hand back the ALREADY-emitted skill, so
+            // a second `--emit-prompts` keeps printing the skill text (no re-fetch). The
+            // existing prompts.json is the source — read its emitSkill if present.
+            const { data: existing } = await FlowMcpCli.#readJson( { 'filePath': promptsPath } )
+            const existingSkill = existing !== null && typeof existing[ 'emitSkill' ] === 'string' ? existing[ 'emitSkill' ] : undefined
+            return { 'result': { 'status': true, 'stage': 1, 'mode': 'emit-prompts', 'skipped': true, promptsPath, statePath, 'emitSkill': existingSkill, dependencyChain } }
         }
 
         // Phase-0/1 wiring (REV-14 Kap. 15): resolveEnv -> buildServerParams ->

--- a/tests/unit/grading-phase2-areas.test.mjs
+++ b/tests/unit/grading-phase2-areas.test.mjs
@@ -459,12 +459,16 @@ describe( 'emit --on-conflict — skip keeps, overwrite rewrites (writeAtomic fi
         } )
     }
 
-    it( 'default (skip) keeps the existing prompts.json on a second emit', async () => {
+    it( 'default (skip) keeps the existing prompts.json but still hands back the skill (round-trip read-back)', async () => {
         const cwd = await freshCwd()
         FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
-        await emitConflict( { cwd, onConflict: null } )
+        const first = await emitConflict( { cwd, onConflict: null } )
         const { result } = await emitConflict( { cwd, onConflict: 'skip' } )
         expect( result.skipped ).toBe( true )
+        // a second --emit-prompts must still surface the already-emitted skill, so the
+        // default skill-text stdout keeps working on re-run without a re-fetch
+        expect( typeof result.emitSkill ).toBe( 'string' )
+        expect( result.emitSkill ).toContain( first.result.taskId )
     } )
 
     it( 'overwrite rewrites the prompts.json (skipped:false) instead of keeping a stale one', async () => {

--- a/tests/unit/grading-phase2-areas.test.mjs
+++ b/tests/unit/grading-phase2-areas.test.mjs
@@ -486,3 +486,34 @@ describe( 'emit --on-conflict — skip keeps, overwrite rewrites (writeAtomic fi
         expect( rewritten.emitSkill.includes( '{{TOOL_NAME}}' ) ).toBe( false )
     } )
 } )
+
+
+// ---- `grading skill <ns>` — read-only printer of the emitted Emit-Skill ---------
+describe( 'gradingSkill — print the emitted Emit-Skill text', () => {
+    afterEach( () => { FlowMcpCli.__testInjectGrading( { grading: null } ) } )
+
+    it( 'returns the filled skill text after an emit', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+        const emitted = await emit( { cwd, phase: null } )
+
+        const { result } = await FlowMcpCli.gradingSkill( { cwd, target: 'demoapi', gradingDataDir: '.flowmcp/grading' } )
+        expect( result.status ).toBe( true )
+        expect( typeof result.skill ).toBe( 'string' )
+        expect( result.skill ).toContain( 'Grading Emit-Skill' )
+        expect( result.skill ).toContain( emitted.result.taskId )
+        expect( result.skill ).toContain( '--consume-scores' )
+        expect( result.skill.includes( '{{TOOL_NAME}}' ) ).toBe( false )
+        expect( result.taskId ).toBe( emitted.result.taskId )
+    } )
+
+    it( 'errors clearly when nothing was emitted yet (no prompts.json)', async () => {
+        const cwd = await freshCwd()
+        FlowMcpCli.__testInjectGrading( { grading: gradingWithStubbedPretest( { ok: true } ) } )
+
+        const { result } = await FlowMcpCli.gradingSkill( { cwd, target: 'demoapi', gradingDataDir: '.flowmcp/grading' } )
+        expect( result.status ).toBe( false )
+        expect( result.error ).toContain( 'No emitted skill' )
+        expect( result.fix ).toContain( '--emit-prompts' )
+    } )
+} )


### PR DESCRIPTION
Closes #104.

The non-deterministic emit writes the self-contained Emit-Skill into the island `prompts.json` (`emitSkill`). Reading the actual skill text required digging that field out of the machine JSON by hand (jq/node). This adds a read-only subcommand:

```bash
flowmcp grading skill etherscan            # raw skill text -> stdout (pipe/redirect ready)
flowmcp grading skill etherscan --json     # structured envelope { status, taskId, emittedAreaSet, skill }
```

- NO SILENT DEFAULT: a missing `prompts.json` (never emitted) or a stale artifact without an `emitSkill` field returns a clear coded error pointing to `--emit-prompts` / `--on-conflict=overwrite`.
- Verified end-to-end with the real CLI against `etherscan`; jest regression for the happy path + the not-emitted error.

Minor bump 4.5.1 → 4.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)