### PR TITLE
ci: codecov should not fail build on upstream GPG flake (#111)

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -39,5 +39,5 @@ jobs:
         with:
           use_oidc: true
           files: ./coverage/lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: unittests


### PR DESCRIPTION
Closes #111

`fail_ci_if_error: true` -> `false` in test-on-push.yml. Codecov's CLI GPG signature is broken upstream, failing the job despite 912/912 tests passing. Coverage still uploaded best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)