### PR TITLE
Pin geo-dzt-toolkit + geo-zhv-toolkit (Memo 116)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flowmcp-cli",
-    "version": "4.5.0",
+    "version": "4.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flowmcp-cli",
-            "version": "4.5.0",
+            "version": "4.6.0",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.0",
@@ -17,9 +17,11 @@
                 "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
                 "flowmcp-grading": "github:FlowMCP/flowmcp-grading#f8bededa2328e09198930367046ca9e4885f4744",
                 "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/geo-csv-tsv-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
+                "geo-dzt-toolkit": "git+https://github.com/FlowMCP/geo-dzt-toolkit.git#c8bdcbf95ab024ee2254af9b3f36b90b3783a361",
                 "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
                 "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
                 "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
+                "geo-zhv-toolkit": "git+https://github.com/FlowMCP/geo-zhv-toolkit.git#10372245125e60472e64ba69fa575f91373215e0",
                 "inquirer": "^12.3.0"
             },
             "bin": {
@@ -3717,6 +3719,15 @@
                 "node": ">=22.0.0"
             }
         },
+        "node_modules/geo-dzt-toolkit": {
+            "version": "0.1.0",
+            "resolved": "git+ssh://git@github.com/FlowMCP/geo-dzt-toolkit.git#c8bdcbf95ab024ee2254af9b3f36b90b3783a361",
+            "integrity": "sha512-w/a3QLS4N09b3RpUTP9Yj41ee/N9wVL9z8LQ52SST5GUIDQyuqq0x+p4aY1LJQNvVuDUhvop4FHJWHgN3828Qg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/geo-geojson-toolkit": {
             "version": "2.0.0",
             "resolved": "git+ssh://git@github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
@@ -3749,6 +3760,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"
+            }
+        },
+        "node_modules/geo-zhv-toolkit": {
+            "version": "0.1.0",
+            "resolved": "git+ssh://git@github.com/FlowMCP/geo-zhv-toolkit.git#10372245125e60472e64ba69fa575f91373215e0",
+            "integrity": "sha512-9emyFx0oX3GDmuq9hM+FzUdsGn7ewV1uQlDRXigQ/y7e7BxkThAK6QpMYGKDFPUcxqoDgML4zyC7vPYomFtwmA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "peerDependencies": {
+                "better-sqlite3": "^11.10.0 || ^12.0.0"
             }
         },
         "node_modules/get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
         "flowmcp": "git+https://github.com/FlowMCP/flowmcp-core.git#de3a08888fa3945a284203d3c6ecd1419caab2bc",
         "flowmcp-grading": "github:FlowMCP/flowmcp-grading#f8bededa2328e09198930367046ca9e4885f4744",
         "geo-csv-tsv-toolkit": "git+https://github.com/FlowMCP/geo-csv-tsv-toolkit.git#5d5e51f8d88a35a20dc44489958e5f376e1674eb",
+        "geo-dzt-toolkit": "git+https://github.com/FlowMCP/geo-dzt-toolkit.git#c8bdcbf95ab024ee2254af9b3f36b90b3783a361",
         "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
         "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
         "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
+        "geo-zhv-toolkit": "git+https://github.com/FlowMCP/geo-zhv-toolkit.git#10372245125e60472e64ba69fa575f91373215e0",
         "inquirer": "^12.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Pin the two new Memo 116 geo add-ons so the geo provider can inject them.

- `geo-dzt-toolkit` (live-query DZT source `dzt`)
- `geo-zhv-toolkit` (local SQLite source `zhv`, peerDep better-sqlite3 already provided by cli)

Verified live via the CLI: `geo_nearby_geo {sources:'zhv'}` → Berlin Hbf (de:11000:900003201); `kg_search_opendatagermany` loads. Pairs with FlowMCP/flowmcp-schemas-private#1501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)