### PR TITLE
Pin geo-idbridge-toolkit for geo geoStation (Memo 118)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "geo-dzt-toolkit": "git+https://github.com/FlowMCP/geo-dzt-toolkit.git#c8bdcbf95ab024ee2254af9b3f36b90b3783a361",
                 "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
                 "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
+                "geo-idbridge-toolkit": "git+https://github.com/FlowMCP/geo-idbridge-toolkit.git#af8e57fccea2ec0716c09acb131b72f73f13f8db",
                 "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
                 "geo-zhv-toolkit": "git+https://github.com/FlowMCP/geo-zhv-toolkit.git#10372245125e60472e64ba69fa575f91373215e0",
                 "inquirer": "^12.3.0"
@@ -3748,6 +3749,18 @@
             },
             "engines": {
                 "node": ">=22.0.0"
+            },
+            "peerDependencies": {
+                "better-sqlite3": "^11.10.0 || ^12.0.0"
+            }
+        },
+        "node_modules/geo-idbridge-toolkit": {
+            "version": "0.1.0",
+            "resolved": "git+ssh://git@github.com/FlowMCP/geo-idbridge-toolkit.git#af8e57fccea2ec0716c09acb131b72f73f13f8db",
+            "integrity": "sha512-Joei56pMg1zGUyKs/5jY3f9qQchxc6/HU0f6s80I7XYH8z0EL2gG+SOBDjo9rrppZSaYcoh4MJmpsKlXdEkh/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
             },
             "peerDependencies": {
                 "better-sqlite3": "^11.10.0 || ^12.0.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "geo-dzt-toolkit": "git+https://github.com/FlowMCP/geo-dzt-toolkit.git#c8bdcbf95ab024ee2254af9b3f36b90b3783a361",
         "geo-geojson-toolkit": "git+https://github.com/FlowMCP/geo-geojson-toolkit.git#af764638f215083da52be785b8e276fa98217b02",
         "geo-gtfs-toolkit": "git+https://github.com/FlowMCP/geo-gtfs-toolkit.git#b868e612dc74c70e6401c9568a044f61ce80cede",
+        "geo-idbridge-toolkit": "git+https://github.com/FlowMCP/geo-idbridge-toolkit.git#af8e57fccea2ec0716c09acb131b72f73f13f8db",
         "geo-overpass-toolkit": "git+https://github.com/FlowMCP/geo-overpass-toolkit.git#708ce2ac4e7a59123bb8863ec4f236f562a011e5",
         "geo-zhv-toolkit": "git+https://github.com/FlowMCP/geo-zhv-toolkit.git#10372245125e60472e64ba69fa575f91373215e0",
         "inquirer": "^12.3.0"


### PR DESCRIPTION
Adds the `geo-idbridge-toolkit` git dependency so the geo `geoStation` handgriff (Memo 118) resolves its IdBridge resolver. Single additive dependency line off main (v4.6.0, no unrelated changes). Toolkit published at FlowMCP/geo-idbridge-toolkit (CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)