### PR TITLE
Neutralize inward-facing references in public docs

### DIFF
--- a/.github/workflows/lint-outward-facing.yml
+++ b/.github/workflows/lint-outward-facing.yml
@@ -1,0 +1,19 @@
+name: Lint Outward-Facing
+
+# Caller for FlowMCP/.github reusable workflow check-outward-facing.yml.
+# Blocks inward-facing content (internal record IDs, decision/chapter refs,
+# German structure markers, the private source-repository name) on this
+# repository's outward-facing surface. Internal working-doc directories and
+# frozen historical version directories are allowlisted.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    uses: FlowMCP/.github/.github/workflows/check-outward-facing.yml@main
+    with:
+      allowlist-paths: "node_modules,dist,generated,.git,archive,.template.md,.template.mdx,tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `flowmcp-cli` are documented here.
 
-## 4.7.0 — 2026-06-20 (Memo 141)
+## 4.7.0 — 2026-06-20
 
 ### Added
 
@@ -21,7 +21,7 @@ All notable changes to `flowmcp-cli` are documented here.
 - Re-pinned `flowmcp-grading` to `2.5.0` (`2974ae8`) for the persona-area emit composition,
   and `geo-dzt-toolkit` to its `getTrails` build.
 
-## 4.4.0 — 2026-06-04 (Memo 107)
+## 4.4.0 — 2026-06-04
 
 ### Added
 
@@ -42,11 +42,11 @@ All notable changes to `flowmcp-cli` are documented here.
 - Pins `flowmcp-grading#v2.3.0` (DeterministicAreaMapper / AreaScorer export, stale-test
   cleanup). Requires the grading tag `v2.3.0` to be published.
 
-## 4.3.0 — 2026-06-04 (Memo 102 / Memo 105)
+## 4.3.0 — 2026-06-04
 
 ### Changed
 
-- Version aligned to the Schemas-Spec `4.3` line for traceability — the single-path grading consolidation (Memo 102) merged after the `v4.2.0` tag without a version bump.
+- Version aligned to the Schemas-Spec `4.3` line for traceability — the single-path grading consolidation merged after the `v4.2.0` tag without a version bump.
 - `flowmcp-grading` dependency pin moved to `v2.2.0`.
 
 ### Added
@@ -59,7 +59,7 @@ All notable changes to `flowmcp-cli` are documented here.
 
 - `flowmcp dev test` single-path command (replaced by `grading deterministic`).
 
-## 4.2.0 — 2026-05-31 (Memo 086)
+## 4.2.0 — 2026-05-31
 
 ### Changed
 
@@ -67,53 +67,53 @@ All notable changes to `flowmcp-cli` are documented here.
 - `flowmcp-grading` dependency pin moved from a bare commit hash to the `v2.0.0` tag.
 - `grading` command area marked **experimental** in the CLI help (surface may change).
 
-## Unreleased — 2026-05-18 (Memo 036)
+## Unreleased — 2026-05-18
 
 ### Breaking Changes
 
-- `flowmcp dev grade` Anthropic-API-Codepath entfernt
-- `--mock` Flag entfernt (war buggy: destructured `prompts` statt `evalPrompts`)
-- `ANTHROPIC_API_KEY` Env-Variable nicht mehr benoetigt
+- `flowmcp dev grade` Anthropic API codepath removed
+- `--mock` flag removed (was buggy: destructured `prompts` instead of `evalPrompts`)
+- `ANTHROPIC_API_KEY` env variable no longer required
 
 ### Added
 
-- `flowmcp dev grade <schema> --emit-prompts` (Phase-1: schreibt `prompts.json` + `state.json`)
-- `flowmcp dev grade <schema> --consume-scores <path>` (Phase-2: berechnet Grade aus extern erzeugten Scores)
-- `--workdir <path>` Option (Default: `proofs/grade-work/`)
-- `--reports-dir <path>` Option (Default: `proofs/grade-reports/`)
-- `--on-conflict <skip|abort>` Option (Default: `skip` — NO-OVERWRITE-Garantie)
-- Atomare File-Writes (write-temp + rename) — crash-safe
-- Schema-Hash (sha256) in jedem Grade-Report
-- Creator + Harness Metadaten im Report (`scoringProtocol: "v1"`)
-- Timestamps pro Phase (startedAt, scoredAt, gradedAt, reportedAt)
-- Absolute Pfade in jedem CLI-Output
+- `flowmcp dev grade <schema> --emit-prompts` (Phase 1: writes `prompts.json` + `state.json`)
+- `flowmcp dev grade <schema> --consume-scores <path>` (Phase 2: computes the grade from externally produced scores)
+- `--workdir <path>` option (default: `proofs/grade-work/`)
+- `--reports-dir <path>` option (default: `proofs/grade-reports/`)
+- `--on-conflict <skip|abort>` option (default: `skip` — NO-OVERWRITE guarantee)
+- Atomic file writes (write-temp + rename) — crash-safe
+- Schema hash (sha256) in every grade report
+- Creator + harness metadata in the report (`scoringProtocol: "v1"`)
+- Timestamps per phase (startedAt, scoredAt, gradedAt, reportedAt)
+- Absolute paths in every CLI output
 
 ### Companion Skills
 
-- `grade-score-single` (im memo-toolkit) — Standalone Single-Schema-Grading
-- `grade-score-batch` (im memo-toolkit) — Standalone Batch-Grading mit Crash-Recovery
+- `grade-score-single` (in the memo-toolkit) — standalone single-schema grading
+- `grade-score-batch` (in the memo-toolkit) — standalone batch grading with crash recovery
 
 ### Migration
 
-`flowmcp dev grade` ist jetzt File-Mode-only. Der typische Workflow ist:
+`flowmcp dev grade` is now file-mode only. The typical workflow is:
 
 ```bash
-# Standalone via Skill (empfohlen)
+# Standalone via skill (recommended)
 /grade-score-single --schema schemas/mudab/marine-data.mjs
 
-# Oder Batch
+# Or batch
 /grade-score-batch --schemas grade-list.txt
 
-# CLI direkt (Power-User)
+# CLI directly (power user)
 flowmcp dev grade <schema> --emit-prompts
 # ... external grader writes scores.json ...
 flowmcp dev grade <schema> --consume-scores <path>/scores.json
 ```
 
-Details: Memo 036 REV-06 + `flowmcp-spec/spec/v4.0.0/22-scoring-protocol.md`.
+Details: see `flowmcp-spec/spec/v4.0.0/22-scoring-protocol.md`.
 
 ---
 
 ## Prior Releases
 
-Siehe Memo 029 REV-09 (Memo 029 PRD F0a-F5) fuer die initiale CLI-Implementierung.
+Earlier releases cover the initial CLI implementation.

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ flowmcp grading deterministic my-namespace/tool/getBalance
 
 ## Testing
 
-> **Memo 102:** `flowmcp dev test` (`project` / `user` / `single`) was **removed**.
+> **Note:** `flowmcp dev test` (`project` / `user` / `single`) was **removed**.
 > Its PASS criterion (HTTP 200 only) was a strict subset of the deterministic
 > grading pretest, which additionally requires non-empty data (HTTP 200 **and**
 > real data). Schema checking now has **one** path: `grading`.


### PR DESCRIPTION
Remove internal record references and German prose from the public CHANGELOG and README. Also wire the reusable outward-facing content lint.

Note: the new `lint-outward-facing` CI check references the reusable workflow at `FlowMCP/.github@main` and will stay red until FlowMCP/.github#27 is merged; re-run CI afterwards.

Closes #123